### PR TITLE
Add opcode tracing hook to interpreter

### DIFF
--- a/libinterpreter/VM.h
+++ b/libinterpreter/VM.h
@@ -12,6 +12,7 @@
 #include <evmc/instructions.h>
 
 #include <boost/optional.hpp>
+#include <functional>
 
 namespace dev
 {
@@ -57,6 +58,9 @@ public:
         evmc_revision _rev, const evmc_message* _msg, uint8_t const* _code, size_t _codeSize);
 
     uint64_t m_io_gas = 0;
+
+    using OperationTracer = std::function<void(uint64_t, Instruction)>;
+    void setOperationTracer(OperationTracer tracer) { m_operationTracer = std::move(tracer); }
 private:
     const evmc_host_interface* m_host = nullptr;
     evmc_host_context* m_context = nullptr;
@@ -69,6 +73,8 @@ private:
     typedef void (VM::*MemFnPtr)();
     MemFnPtr m_bounce = nullptr;
     uint64_t m_nSteps = 0;
+
+    OperationTracer m_operationTracer;
 
     // return bytes
     owning_bytes_ref m_output;
@@ -133,7 +139,7 @@ private:
     std::vector<uint64_t> m_jumpDests;
     int64_t verifyJumpDest(intx::uint256 const& _dest, bool _throw = true);
 
-    void onOperation() {}
+    void onOperation() { if (m_operationTracer) m_operationTracer(m_PC, m_OP); }
     void adjustStack(int _removed, int _added);
     uint64_t gasForMem(intx::uint512 const& _size);
     void updateIOGas();
@@ -153,7 +159,7 @@ private:
         uint64_t w = uint64_t(v);
         return w;
     }
-    
+
     template<class T> uint64_t toInt15(T v)
     {
         // check for overflow

--- a/mcp/node/evm/Executive.cpp
+++ b/mcp/node/evm/Executive.cpp
@@ -3,6 +3,7 @@
 
 #include <libevm/LegacyVM.h>
 #include <libevm/VMFactory.h>
+#include <libinterpreter/VM.h>
 #include <mcp/common/Exceptions.h>
 #include <mcp/common/stopwatch.hpp>
 #include <mcp/core/param.hpp>
@@ -335,9 +336,15 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
 
             // Create VM instance. Force Interpreter if tracing requested.
             auto vm = VMFactory::create();
+            if (auto* intVm = dynamic_cast<dev::eth::VM*>(vm.get()))
+            {
+                intVm->setOperationTracer([&](uint64_t pc, dev::eth::Instruction inst) {
+                    BOOST_LOG(m_log.trace) << pc << ": " << instructionInfo(inst).name;
+                });
+            }
             if (m_isCreation)
             {
-				m_output = vm->exec(m_gas, *m_ext, m_tracer/*, _onOp*/);
+                                m_output = vm->exec(m_gas, *m_ext, m_tracer/*, _onOp*/);
                 if (m_res)
                 {
                     m_res->gasForDeposit = m_gas;


### PR DESCRIPTION
## Summary
- add operation tracing callback to interpreter VM and hook into opcode dispatcher
- log executed opcodes in Executive::go via BOOST_LOG trace level

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost, missing: Boost_INCLUDE_DIR date_time filesystem system log log_setup thread program_options regex chrono atomic)*
- `apt-get update` *(fails: repository InRelease not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be82bcf9088329a4033a7b58e4fb6d