### PR TITLE
Integrate tracer hooks into VM execution

### DIFF
--- a/mcp/node/evm/Executive.cpp
+++ b/mcp/node/evm/Executive.cpp
@@ -3,13 +3,13 @@
 
 #include <libevm/LegacyVM.h>
 #include <libevm/VMFactory.h>
-#include <libinterpreter/VM.h>
 #include <mcp/common/Exceptions.h>
 #include <mcp/common/stopwatch.hpp>
 #include <mcp/core/param.hpp>
 #include <mcp/node/chain.hpp>
 #include <numeric>
 #include <iomanip>
+#include <limits>
 
 using namespace std;
 using namespace dev;
@@ -122,6 +122,7 @@ bool mcp::Executive::call(Address const& _receiveAddress, Address const& _sender
 	//	m_tracer->CaptureStart(_senderAddress, _receiveAddress, false, _data.toBytes(), uint64_t(m_gas), _value);
 
     dev::eth::CallParameters params(_senderAddress, _receiveAddress, _receiveAddress, _value, _value, _gas, _data, nullptr/*, {}*/);
+    params.tracer = m_tracer;
     return call(params, _gasPrice, _senderAddress);
 }
 
@@ -160,14 +161,14 @@ bool mcp::Executive::call(dev::eth::CallParameters const& _p, u256 const& _gasPr
 	else
 	{
 		m_gas = _p.gas;
-		if (m_s.addressHasCode(_p.codeAddress))
-		{
-			bytes const& c = m_s.code(_p.codeAddress);
-			h256 codeHash = m_s.codeHash(_p.codeAddress);
-			m_ext = std::make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, _p.receiveAddress,
-				_p.senderAddress, _origin, _p.apparentValue, _gasPrice, _p.data, &c, codeHash,
-				0, m_depth, false, _p.staticCall);
-		}
+                if (m_s.addressHasCode(_p.codeAddress))
+                {
+                        bytes const& c = m_s.code(_p.codeAddress);
+                        h256 codeHash = m_s.codeHash(_p.codeAddress);
+                        m_ext = std::make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, _p.receiveAddress,
+                                _p.senderAddress, _origin, _p.apparentValue, _gasPrice, _p.data, &c, codeHash,
+                                0, m_depth, false, _p.staticCall, m_tracer);
+                }
 	}
 
 	////call trace action
@@ -296,8 +297,8 @@ bool mcp::Executive::executeCreate(Address const& _sender, u256 const& _endowmen
     // Schedule _init execution if not empty.
 	if (!_init.empty())
 	{
-		m_ext = std::make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, m_newAddress, _sender, _origin, _endowment, _gasPrice,
-			dev::bytesConstRef(), _init, sha3(_init), 0, m_depth, true, false);
+                m_ext = std::make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, m_newAddress, _sender, _origin, _endowment, _gasPrice,
+                        dev::bytesConstRef(), _init, sha3(_init), 0, m_depth, true, false, m_tracer);
 	}
 
 	if (m_tracer && m_ext && topCall())
@@ -336,31 +337,35 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
 			//mcp::uint256_t start_gas_used = gasUsed();
 			//int64_t start_refunds = m_ext->sub.refunds;
 
-            // Set up opcode logging callback for debugging - connect both BOOST_LOG and shared_ptr tracer
-            g_opcodeLogCallback = OpcodeLogCallback([this](uint64_t pc, Instruction op, const std::string& opName, const VM* vm) {
-                // Log to BOOST_LOG for debugging output
-                BOOST_LOG(m_log.trace) << "EVM Opcode: TxHash=" << m_t.sha3().hexPrefixed() 
-                                      << " PC=" << pc << " OP=" << opName 
-                                      << " (0x" << std::hex << static_cast<int>(op) << std::dec << ")";
-                
-                // Connect to shared_ptr tracer for structured tracing
-                if (m_tracer && m_ext) {
-                    // Call CaptureState with nullptr for VMFace since we don't have access to it here
-                    // The tracer should handle this gracefully
-                    try {
-                        m_tracer->CaptureState(pc, op, 0, static_cast<uint64_t>(m_gas), nullptr, m_ext.get());
-                    } catch (...) {
-                        // Protect against tracer failures affecting VM execution
-                        BOOST_LOG(m_log.debug) << "Tracer CaptureState failed for PC=" << pc << " OP=" << opName;
+            OnOpFunc tracerOnOp;
+            if (m_tracer)
+            {
+                tracerOnOp = [this](uint64_t /*steps*/, uint64_t pc, Instruction op, bigint /*newMemSize*/, bigint gasCost,
+                                     bigint gas, VMFace const* vm, ExtVMFace const* ext) {
+                    auto toUint64 = [](bigint const& value) -> uint64_t {
+                        if (value <= 0)
+                            return 0;
+                        if (value > std::numeric_limits<uint64_t>::max())
+                            return std::numeric_limits<uint64_t>::max();
+                        return static_cast<uint64_t>(value);
+                    };
+
+                    try
+                    {
+                        m_tracer->CaptureState(pc, op, toUint64(gasCost), toUint64(gas), vm, ext);
                     }
-                }
-            });
+                    catch (...)
+                    {
+                        BOOST_LOG(m_log.debug) << "Tracer CaptureState failed for PC=" << pc << " opcode=" << static_cast<int>(op);
+                    }
+                };
+            }
 
             // Create VM instance. Force Interpreter if tracing requested.
             auto vm = VMFactory::create();
             if (m_isCreation)
             {
-				m_output = vm->exec(m_gas, *m_ext, m_tracer/*, _onOp*/);
+                                m_output = vm->exec(m_gas, *m_ext, m_tracer, tracerOnOp);
                 if (m_res)
                 {
                     m_res->gasForDeposit = m_gas;
@@ -402,7 +407,7 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
             }
             else
             //{
-                m_output = vm->exec(m_gas, *m_ext, m_tracer/*, _onOp*/);
+                m_output = vm->exec(m_gas, *m_ext, m_tracer, tracerOnOp);
 
 				////call trace result 
 				//std::shared_ptr<mcp::call_trace_result> call_result(std::make_shared<mcp::call_trace_result>());
@@ -472,8 +477,6 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
         cnote << "VM took:" << t.elapsed() << "; gas used: " << (sgas - m_endGas);
 #endif
         
-        // Clear the opcode logging callback
-        g_opcodeLogCallback = nullptr;
     }
     return true;
 }

--- a/mcp/node/evm/ExtVM.cpp
+++ b/mcp/node/evm/ExtVM.cpp
@@ -125,14 +125,17 @@ evmc_status_code transactionExceptionToEvmcStatusCode(TransactionException ex) n
 
 
 CallResult ExtVM::call(CallParameters& _p)
-{   
-    Executive e(m_s, envInfo(), m_sealEngine, /*m_s.traces,*/ depth + 1, _p.tracer);
-    if (_p.tracer)
+{
+    std::shared_ptr<EVMLogger> tracer = _p.tracer ? _p.tracer : m_tracer;
+    _p.tracer = tracer;
+
+    Executive e(m_s, envInfo(), m_sealEngine, /*m_s.traces,*/ depth + 1, tracer);
+    if (tracer)
     {
         std::shared_ptr<dev::u256> _pValue = nullptr;
         if (*_p.op != Instruction::STATICCALL)
             _pValue = std::make_shared<dev::u256>(_p.valueTransfer);
-        _p.tracer->CaptureEnter(*_p.op, _p.senderAddress, _p.codeAddress, _p.data.toBytes(), uint64_t(_p.gas), _pValue);
+        tracer->CaptureEnter(*_p.op, _p.senderAddress, _p.codeAddress, _p.data.toBytes(), uint64_t(_p.gas), _pValue);
     }
 
     if (!e.call(_p, gasPrice, origin))
@@ -140,8 +143,8 @@ CallResult ExtVM::call(CallParameters& _p)
         go(depth, e/*, _p.onOp*/);
         e.accrueSubState(sub);
     }
-    if (_p.tracer)
-        _p.tracer->CaptureExit(e.Output(), uint64_t(_p.gas - e.gas()), e.getException());
+    if (tracer)
+        tracer->CaptureExit(e.Output(), uint64_t(_p.gas - e.gas()), e.getException());
     _p.gas = e.gas();
 
     return {transactionExceptionToEvmcStatusCode(e.getException()), e.takeOutput()};
@@ -164,7 +167,9 @@ void ExtVM::setStore(u256 _n, u256 _v)
 
 CreateResult ExtVM::create(u256 _endowment, u256& io_gas, bytesConstRef _code, Instruction _op, u256 _salt, std::shared_ptr<EVMLogger> _tracer/*, OnOpFunc const& _onOp*/)
 {
-    Executive e(m_s, envInfo(), m_sealEngine, /*m_s.traces,*/ depth + 1, _tracer);
+    std::shared_ptr<EVMLogger> tracer = _tracer ? _tracer : m_tracer;
+
+    Executive e(m_s, envInfo(), m_sealEngine, /*m_s.traces,*/ depth + 1, tracer);
     bool result = false;
     if (_op == Instruction::CREATE)
         result = e.createOpcode(myAddress, _endowment, gasPrice, io_gas, _code, origin);
@@ -176,13 +181,13 @@ CreateResult ExtVM::create(u256 _endowment, u256& io_gas, bytesConstRef _code, I
 
     if (!result)
     {
-        if (_tracer)
-            _tracer->CaptureEnter(_op, myAddress, e.newAddress(), _code.toBytes(), uint64_t(io_gas), std::make_shared<dev::u256>(_endowment));
+        if (tracer)
+            tracer->CaptureEnter(_op, myAddress, e.newAddress(), _code.toBytes(), uint64_t(io_gas), std::make_shared<dev::u256>(_endowment));
 
         go(depth, e/*, _onOp*/);
         e.accrueSubState(sub);
-        if (_tracer)
-            _tracer->CaptureExit(e.Output(), uint64_t(io_gas - e.gas()), e.getException());
+        if (tracer)
+            tracer->CaptureExit(e.Output(), uint64_t(io_gas - e.gas()), e.getException());
     }
     io_gas = e.gas();
     return {transactionExceptionToEvmcStatusCode(e.getException()), e.takeOutput(), e.newAddress()};

--- a/mcp/node/evm/ExtVM.h
+++ b/mcp/node/evm/ExtVM.h
@@ -25,6 +25,7 @@
 #include <mcp/core/param.hpp>
 #include <functional>
 #include <map>
+#include <memory>
 
 namespace dev
 {
@@ -39,12 +40,13 @@ public:
     ExtVM(mcp::chain_state& _s, EnvInfo const& _envInfo, mcp::SealEngineFace const& _sealEngine, Address _myAddress,
         Address _caller, Address _origin, u256 _value, u256 _gasPrice, bytesConstRef _data,
         bytesConstRef _code, h256 const& _codeHash, u256 const& _version, unsigned _depth,
-        bool _isCreate, bool _staticCall)
+        bool _isCreate, bool _staticCall, std::shared_ptr<dev::eth::EVMLogger> _tracer = nullptr)
       : ExtVMFace(_envInfo, _myAddress, _caller, _origin, _value, _gasPrice, _data, _code.toBytes(),
             _codeHash, _version, _depth, _isCreate, _staticCall),
         m_s(_s),
         m_sealEngine(_sealEngine),
-        m_evmSchedule(initEvmSchedule(envInfo().mci(), _version))
+        m_evmSchedule(initEvmSchedule(envInfo().mci(), _version)),
+        m_tracer(_tracer)
     {
         // Contract: processing account must exist. In case of CALL, the ExtVM
         // is created only if an account has code (so exist). In case of CREATE
@@ -119,6 +121,7 @@ private:
     mcp::chain_state & m_s;  ///< A reference to the base state.
     mcp::SealEngineFace const& m_sealEngine;
     EVMSchedule const& m_evmSchedule;
+    std::shared_ptr<dev::eth::EVMLogger> m_tracer;
 };
 
 }

--- a/mcp/node/tracers/4byte.cpp
+++ b/mcp/node/tracers/4byte.cpp
@@ -7,10 +7,14 @@ void mcp::FourByteTracer::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev:
 {
     if (_input.size() >= 4)
         store(dev::bytes(_input.begin(), _input.begin()+4), _input.size()-4);
+
+    Tracer::CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value);
 }
 
 void mcp::FourByteTracer::CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to, dev::bytes const& _input, uint64_t _gas, std::shared_ptr<dev::u256> _value)
 {
+    Tracer::CaptureEnter(_inst, _from, _to, _input, _gas, _value);
+
     if (_input.size() < 4)
         return;
 

--- a/mcp/node/tracers/Call.cpp
+++ b/mcp/node/tracers/Call.cpp
@@ -33,6 +33,7 @@ void mcp::CallTracer::callFrame::processOutput(dev::bytes const& _output, Transa
 void mcp::CallTracer::CaptureTxStart(uint64_t _gasLimit)
 {
     gasLimit = _gasLimit;
+    Tracer::CaptureTxStart(_gasLimit);
 }
 
 void mcp::CallTracer::CaptureTxEnd(uint64_t _restGas)
@@ -44,6 +45,8 @@ void mcp::CallTracer::CaptureTxEnd(uint64_t _restGas)
         // Logs are not emitted when the call fails
         clearFailedLogs(callstack[0], false);
     }
+
+    Tracer::CaptureTxEnd(_restGas);
 }
 
 void mcp::CallTracer::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to, bool _create, dev::bytes const& _input, uint64_t _gas, dev::u256 _value)
@@ -54,15 +57,20 @@ void mcp::CallTracer::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Add
     callstack[0].Input = _input;
     callstack[0].Gas = gasLimit;
     callstack[0].Value = std::make_shared<dev::u256>(_value);
+
+    Tracer::CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value);
 }
 
 void mcp::CallTracer::CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
 {
     callstack[0].processOutput(_output, _excepted);
+    Tracer::CaptureEnd(_output, _gasUsed, _excepted);
 }
 
 void mcp::CallTracer::CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to, dev::bytes const& _input, uint64_t _gas, std::shared_ptr<dev::u256> _value)
 {
+    Tracer::CaptureEnter(_inst, _from, _to, _input, _gas, _value);
+
     if (m_options.OnlyTopCall)
         return;
 
@@ -71,6 +79,8 @@ void mcp::CallTracer::CaptureEnter(dev::eth::Instruction _inst, dev::Address con
 
 void mcp::CallTracer::CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
 {
+    Tracer::CaptureExit(_output, _gasUsed, _excepted);
+
     if (m_options.OnlyTopCall)
         return;
 
@@ -90,6 +100,8 @@ void mcp::CallTracer::CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, 
 
 void mcp::CallTracer::CaptureState(uint64_t PC, dev::eth::Instruction inst, uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
 {
+    Tracer::CaptureState(PC, inst, gasCost, gas, _vm, voidExt);
+
     // Only logs need to be captured via opcode processing
     if (!m_options.WithLog)
         return;

--- a/mcp/node/tracers/OpCode.cpp
+++ b/mcp/node/tracers/OpCode.cpp
@@ -4,13 +4,15 @@
 
 using namespace dev::eth;
 void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
-	uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
+        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
 {
-	// check if already accumulated the specified number of logs
-	if (m_options.limit != 0 && m_options.limit <= m_outValue.size())
-		return;
+        Tracer::CaptureState(PC, inst, gasCost, gas, _vm, voidExt);
 
-	ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
+        // check if already accumulated the specified number of logs
+        if (m_options.limit != 0 && m_options.limit <= m_outValue.size())
+                return;
+
+        ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
 	auto vm = dynamic_cast<LegacyVM const*>(_vm);
 
 	mcp::json r = mcp::json::object();

--- a/mcp/node/tracers/PreState.cpp
+++ b/mcp/node/tracers/PreState.cpp
@@ -8,10 +8,13 @@ using namespace dev::eth;
 void mcp::PreStateTracer::CaptureTxStart(uint64_t _gasLimit)
 {
     gasLimit = _gasLimit;
+    Tracer::CaptureTxStart(_gasLimit);
 }
 
 void mcp::PreStateTracer::CaptureTxEnd(uint64_t _restGas)
 {
+    Tracer::CaptureTxEnd(_restGas);
+
     if (!m_options.DiffMode)
         return;
 
@@ -103,10 +106,14 @@ void mcp::PreStateTracer::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev:
 
     if (_create && m_options.DiffMode)
         created[_to] = true;
+
+    Tracer::CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value);
 }
 
 void mcp::PreStateTracer::CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
 {
+    Tracer::CaptureEnd(_output, _gasUsed, _excepted);
+
     if (m_options.DiffMode)
         return;
 
@@ -118,6 +125,8 @@ void mcp::PreStateTracer::CaptureEnd(dev::bytes const& _output, uint64_t _gasUse
 
 void mcp::PreStateTracer::CaptureState(uint64_t PC, dev::eth::Instruction inst, uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
 {
+    Tracer::CaptureState(PC, inst, gasCost, gas, _vm, voidExt);
+
     auto vm = dynamic_cast<LegacyVM const*>(_vm);
     u256s stackData = vm->stack();
     auto stackLen = stackData.size();

--- a/mcp/node/tracers/Tracer.cpp
+++ b/mcp/node/tracers/Tracer.cpp
@@ -12,6 +12,40 @@ using namespace mcp;
 
 namespace
 {
+        bool isReservedConfigKey(std::string const& key)
+        {
+                return key == "tracer" || key == "type" || key == "name" || key == "config" || key == "tracerConfig" || key == "timeout" || key == "reexec";
+        }
+
+        mcp::json extractInlineConfig(mcp::json const& definition)
+        {
+                if (!definition.is_object())
+                        return mcp::json::object();
+
+                mcp::json config = mcp::json::object();
+                for (auto it = definition.begin(); it != definition.end(); ++it)
+                {
+                        if (isReservedConfigKey(it.key()))
+                                continue;
+
+                        config[it.key()] = it.value();
+                }
+
+                return config;
+        }
+
+        void mergeConfig(mcp::json& baseConfig, mcp::json const& inlineConfig)
+        {
+                if (!inlineConfig.is_object() || inlineConfig.empty())
+                        return;
+
+                if (!baseConfig.is_object())
+                        baseConfig = mcp::json::object();
+
+                for (auto it = inlineConfig.begin(); it != inlineConfig.end(); ++it)
+                        baseConfig[it.key()] = it.value();
+        }
+
         std::string toLowerCopy(std::string value)
         {
                 std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
@@ -147,6 +181,9 @@ std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionRe
                                         else if (definition.count("tracerConfig"))
                                                 config = definition["tracerConfig"];
 
+                                        auto inlineConfig = extractInlineConfig(definition);
+                                        mergeConfig(config, inlineConfig);
+
                                         if (definition.count("name") && definition["name"].is_string())
                                                 resultKey = definition["name"].get<std::string>();
                                         else if (!tracerName.empty())
@@ -174,8 +211,12 @@ std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionRe
         if (_param.count("tracer") && !_param["tracer"].empty())
         {
                 mcp::json config;
-                if (_param.count("tracerConfig"))
+                if (_param.count("config"))
+                        config = _param["config"];
+                else if (_param.count("tracerConfig"))
                         config = _param["tracerConfig"];
+
+                mergeConfig(config, extractInlineConfig(_param));
 
                 return createTracerByName(_param["tracer"], _er, config);
         }

--- a/mcp/node/tracers/Tracer.cpp
+++ b/mcp/node/tracers/Tracer.cpp
@@ -83,15 +83,9 @@ namespace
                 return std::make_shared<OpCode>(er, config);
         }
 
-        template <class Func>
-        void forEach(std::vector<TracerHookSet::NamedTracer>& tracers, Func&& fn)
-        {
-                for (auto& entry : tracers)
-                        fn(entry.first, entry.second.get());
-        }
 }
 
-void TracerHookSet::addTracer(std::string name, std::shared_ptr<Tracer> tracer)
+void Tracer::addTracer(std::string name, std::shared_ptr<Tracer> tracer)
 {
         if (!tracer)
                 return;
@@ -102,51 +96,64 @@ void TracerHookSet::addTracer(std::string name, std::shared_ptr<Tracer> tracer)
         m_tracers.emplace_back(std::move(name), std::move(tracer));
 }
 
-void TracerHookSet::CaptureTxStart(uint64_t _gasLimit)
+namespace
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureTxStart(_gasLimit); });
+        template <class Func>
+        void dispatch(std::vector<Tracer::NamedTracer> const& tracers, Func&& fn)
+        {
+                for (auto const& entry : tracers)
+                {
+                        if (entry.second)
+                                fn(*entry.second);
+                }
+        }
 }
 
-void TracerHookSet::CaptureTxEnd(uint64_t _restGas)
+void Tracer::CaptureTxStart(uint64_t _gasLimit)
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureTxEnd(_restGas); });
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureTxStart(_gasLimit); });
 }
 
-void TracerHookSet::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to,
+void Tracer::CaptureTxEnd(uint64_t _restGas)
+{
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureTxEnd(_restGas); });
+}
+
+void Tracer::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to,
         bool _create, dev::bytes const& _input, uint64_t _gas, dev::u256 _value)
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value); });
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value); });
 }
 
-void TracerHookSet::CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
+void Tracer::CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureEnd(_output, _gasUsed, _excepted); });
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureEnd(_output, _gasUsed, _excepted); });
 }
 
-void TracerHookSet::CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to,
+void Tracer::CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to,
         dev::bytes const& _input, uint64_t _gas, std::shared_ptr<dev::u256> _value)
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureEnter(_inst, _from, _to, _input, _gas, _value); });
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureEnter(_inst, _from, _to, _input, _gas, _value); });
 }
 
-void TracerHookSet::CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
+void Tracer::CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureExit(_output, _gasUsed, _excepted); });
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureExit(_output, _gasUsed, _excepted); });
 }
 
-void TracerHookSet::CaptureState(uint64_t PC, dev::eth::Instruction inst,
+void Tracer::CaptureState(uint64_t PC, dev::eth::Instruction inst,
         uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureState(PC, inst, gasCost, gas, _vm, voidExt); });
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureState(PC, inst, gasCost, gas, _vm, voidExt); });
 }
 
-void TracerHookSet::CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
+void Tracer::CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
         uint64_t _gasCost, uint64_t _gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* _voidExt)
 {
-        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureFault(_PC, _inst, _gasCost, _gas, _vm, _voidExt); });
+        dispatch(m_tracers, [&](Tracer& tracer) { tracer.CaptureFault(_PC, _inst, _gasCost, _gas, _vm, _voidExt); });
 }
 
-mcp::json TracerHookSet::GetResult()
+mcp::json Tracer::GetResult()
 {
         if (m_tracers.empty())
                 return mcp::json::object();
@@ -167,7 +174,7 @@ std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionRe
                 auto const& tracerArray = _param["tracers"];
                 if (tracerArray.is_array() && !tracerArray.empty())
                 {
-                        auto hookSet = std::make_shared<TracerHookSet>();
+                        auto rootTracer = std::make_shared<Tracer>();
 
                         for (auto const& definition : tracerArray)
                         {
@@ -211,11 +218,11 @@ std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionRe
                                 if (resultKey.empty())
                                         resultKey = tracerName;
 
-                                hookSet->addTracer(resultKey, tracer);
+                                rootTracer->addTracer(resultKey, tracer);
                         }
 
-                        if (!hookSet->empty())
-                                return hookSet;
+                        if (rootTracer->hasChildren())
+                                return rootTracer;
                 }
         }
 
@@ -229,7 +236,8 @@ std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionRe
 
                 mergeConfig(config, extractInlineConfig(_param));
 
-                return createTracerByName(_param["tracer"], _er, config);
+                if (_param["tracer"].is_string())
+                        return createTracerByName(_param["tracer"].get<std::string>(), _er, config);
         }
 
         return std::make_shared<OpCode>(_er, _param);

--- a/mcp/node/tracers/Tracer.cpp
+++ b/mcp/node/tracers/Tracer.cpp
@@ -84,67 +84,79 @@ namespace
         }
 
         template <class Func>
-        void dispatchToAll(std::vector<TracerMultiplexer::NamedTracer>& tracers, Func&& fn)
+        void forEach(std::vector<TracerHookSet::NamedTracer>& tracers, Func&& fn)
         {
                 for (auto& entry : tracers)
-                        fn(entry.second.get());
+                        fn(entry.first, entry.second.get());
         }
 }
 
-void TracerMultiplexer::CaptureTxStart(uint64_t _gasLimit)
+void TracerHookSet::addTracer(std::string name, std::shared_ptr<Tracer> tracer)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureTxStart(_gasLimit); });
+        if (!tracer)
+                return;
+
+        if (name.empty())
+                name = "tracer" + std::to_string(m_tracers.size());
+
+        m_tracers.emplace_back(std::move(name), std::move(tracer));
 }
 
-void TracerMultiplexer::CaptureTxEnd(uint64_t _restGas)
+void TracerHookSet::CaptureTxStart(uint64_t _gasLimit)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureTxEnd(_restGas); });
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureTxStart(_gasLimit); });
 }
 
-void TracerMultiplexer::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to,
+void TracerHookSet::CaptureTxEnd(uint64_t _restGas)
+{
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureTxEnd(_restGas); });
+}
+
+void TracerHookSet::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to,
         bool _create, dev::bytes const& _input, uint64_t _gas, dev::u256 _value)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value); });
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value); });
 }
 
-void TracerMultiplexer::CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
+void TracerHookSet::CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureEnd(_output, _gasUsed, _excepted); });
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureEnd(_output, _gasUsed, _excepted); });
 }
 
-void TracerMultiplexer::CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to,
+void TracerHookSet::CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to,
         dev::bytes const& _input, uint64_t _gas, std::shared_ptr<dev::u256> _value)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureEnter(_inst, _from, _to, _input, _gas, _value); });
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureEnter(_inst, _from, _to, _input, _gas, _value); });
 }
 
-void TracerMultiplexer::CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
+void TracerHookSet::CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureExit(_output, _gasUsed, _excepted); });
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureExit(_output, _gasUsed, _excepted); });
 }
 
-void TracerMultiplexer::CaptureState(uint64_t PC, dev::eth::Instruction inst,
+void TracerHookSet::CaptureState(uint64_t PC, dev::eth::Instruction inst,
         uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureState(PC, inst, gasCost, gas, _vm, voidExt); });
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureState(PC, inst, gasCost, gas, _vm, voidExt); });
 }
 
-void TracerMultiplexer::CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
+void TracerHookSet::CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
         uint64_t _gasCost, uint64_t _gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* _voidExt)
 {
-        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureFault(_PC, _inst, _gasCost, _gas, _vm, _voidExt); });
+        forEach(m_tracers, [&](std::string const&, Tracer* tracer) { tracer->CaptureFault(_PC, _inst, _gasCost, _gas, _vm, _voidExt); });
 }
 
-mcp::json TracerMultiplexer::GetResult()
+mcp::json TracerHookSet::GetResult()
 {
         if (m_tracers.empty())
                 return mcp::json::object();
 
+        if (m_tracers.size() == 1)
+                return m_tracers.front().second->GetResult();
+
         mcp::json result = mcp::json::object();
         for (auto const& entry : m_tracers)
-        {
                 result[entry.first] = entry.second->GetResult();
-        }
         return result;
 }
 
@@ -155,8 +167,7 @@ std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionRe
                 auto const& tracerArray = _param["tracers"];
                 if (tracerArray.is_array() && !tracerArray.empty())
                 {
-                        std::vector<TracerMultiplexer::NamedTracer> tracers;
-                        tracers.reserve(tracerArray.size());
+                        auto hookSet = std::make_shared<TracerHookSet>();
 
                         for (auto const& definition : tracerArray)
                         {
@@ -200,11 +211,11 @@ std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionRe
                                 if (resultKey.empty())
                                         resultKey = tracerName;
 
-                                tracers.emplace_back(resultKey, tracer);
+                                hookSet->addTracer(resultKey, tracer);
                         }
 
-                        if (!tracers.empty())
-                                return std::make_shared<TracerMultiplexer>(std::move(tracers));
+                        if (!hookSet->empty())
+                                return hookSet;
                 }
         }
 

--- a/mcp/node/tracers/Tracer.cpp
+++ b/mcp/node/tracers/Tracer.cpp
@@ -4,32 +4,181 @@
 #include "Call.hpp"
 #include "PreState.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <string>
+
 using namespace mcp;
+
+namespace
+{
+        std::string toLowerCopy(std::string value)
+        {
+                std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+                return value;
+        }
+
+        std::shared_ptr<Tracer> createTracerByName(std::string const& tracerName, mcp::ExecutionResult& er, mcp::json const& config)
+        {
+                auto normalized = toLowerCopy(tracerName);
+
+                if (normalized == "noop" || normalized == "nooptracer")
+                        return std::make_shared<Tracer>();
+
+                if (normalized == "4byte" || normalized == "4bytetracer")
+                        return std::make_shared<FourByteTracer>();
+
+                if (normalized == "call" || normalized == "calltracer")
+                {
+                        if (config.is_null() || config.empty())
+                                return std::make_shared<CallTracer>(er);
+                        return std::make_shared<CallTracer>(er, config);
+                }
+
+                if (normalized == "prestate" || normalized == "prestatetracer")
+                {
+                        if (config.is_null() || config.empty())
+                                return std::make_shared<PreStateTracer>(er);
+                        return std::make_shared<PreStateTracer>(er, config);
+                }
+
+                if (normalized == "opcode" || normalized == "opcodetracer" || normalized == "optracer" || normalized == "structlogger" || normalized == "structlogs")
+                        return std::make_shared<OpCode>(er, config);
+
+                // Default tracer falls back to opcode tracing while preserving any configuration
+                return std::make_shared<OpCode>(er, config);
+        }
+
+        template <class Func>
+        void dispatchToAll(std::vector<TracerMultiplexer::NamedTracer>& tracers, Func&& fn)
+        {
+                for (auto& entry : tracers)
+                        fn(entry.second.get());
+        }
+}
+
+void TracerMultiplexer::CaptureTxStart(uint64_t _gasLimit)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureTxStart(_gasLimit); });
+}
+
+void TracerMultiplexer::CaptureTxEnd(uint64_t _restGas)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureTxEnd(_restGas); });
+}
+
+void TracerMultiplexer::CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to,
+        bool _create, dev::bytes const& _input, uint64_t _gas, dev::u256 _value)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureStart(_voidExt, _from, _to, _create, _input, _gas, _value); });
+}
+
+void TracerMultiplexer::CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureEnd(_output, _gasUsed, _excepted); });
+}
+
+void TracerMultiplexer::CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to,
+        dev::bytes const& _input, uint64_t _gas, std::shared_ptr<dev::u256> _value)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureEnter(_inst, _from, _to, _input, _gas, _value); });
+}
+
+void TracerMultiplexer::CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureExit(_output, _gasUsed, _excepted); });
+}
+
+void TracerMultiplexer::CaptureState(uint64_t PC, dev::eth::Instruction inst,
+        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureState(PC, inst, gasCost, gas, _vm, voidExt); });
+}
+
+void TracerMultiplexer::CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
+        uint64_t _gasCost, uint64_t _gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* _voidExt)
+{
+        dispatchToAll(m_tracers, [&](Tracer* tracer) { tracer->CaptureFault(_PC, _inst, _gasCost, _gas, _vm, _voidExt); });
+}
+
+mcp::json TracerMultiplexer::GetResult()
+{
+        if (m_tracers.empty())
+                return mcp::json::object();
+
+        mcp::json result = mcp::json::object();
+        for (auto const& entry : m_tracers)
+        {
+                result[entry.first] = entry.second->GetResult();
+        }
+        return result;
+}
 
 std::shared_ptr<Tracer> mcp::NewTracer(mcp::json const& _param, mcp::ExecutionResult& _er)
 {
-    if (_param.count("tracer") && !_param["tracer"].empty())
-    {
-        if (_param["tracer"] == "noopTracer")
-            return std::make_shared<Tracer>();
-        else if (_param["tracer"] == "4byteTracer")
-            return std::make_shared<FourByteTracer>();
-        else if (_param["tracer"] == "callTracer")
+        if (_param.is_object() && _param.count("tracers"))
         {
-            if (_param.count("tracerConfig"))
-                return std::make_shared<CallTracer>(_er, _param["tracerConfig"]);
-            else
-                return std::make_shared<CallTracer>(_er);
-        }
-        else if (_param["tracer"] == "prestateTracer")
-        {
-            if (_param.count("tracerConfig"))
-                return std::make_shared<PreStateTracer>(_er, _param["tracerConfig"]);
-            else
-                return std::make_shared<PreStateTracer>(_er);
-        }
-            
-    }
+                auto const& tracerArray = _param["tracers"];
+                if (tracerArray.is_array() && !tracerArray.empty())
+                {
+                        std::vector<TracerMultiplexer::NamedTracer> tracers;
+                        tracers.reserve(tracerArray.size());
 
-    return std::make_shared<OpCode>(_er, _param);
+                        for (auto const& definition : tracerArray)
+                        {
+                                std::string tracerName;
+                                std::string resultKey;
+                                mcp::json config;
+
+                                if (definition.is_string())
+                                {
+                                        tracerName = definition.get<std::string>();
+                                        resultKey = tracerName;
+                                }
+                                else if (definition.is_object())
+                                {
+                                        if (definition.count("tracer") && definition["tracer"].is_string())
+                                                tracerName = definition["tracer"].get<std::string>();
+                                        else if (definition.count("type") && definition["type"].is_string())
+                                                tracerName = definition["type"].get<std::string>();
+
+                                        if (definition.count("config"))
+                                                config = definition["config"];
+                                        else if (definition.count("tracerConfig"))
+                                                config = definition["tracerConfig"];
+
+                                        if (definition.count("name") && definition["name"].is_string())
+                                                resultKey = definition["name"].get<std::string>();
+                                        else if (!tracerName.empty())
+                                                resultKey = tracerName;
+                                }
+
+                                if (tracerName.empty())
+                                        continue;
+
+                                auto tracer = createTracerByName(tracerName, _er, config);
+                                if (!tracer)
+                                        continue;
+
+                                if (resultKey.empty())
+                                        resultKey = tracerName;
+
+                                tracers.emplace_back(resultKey, tracer);
+                        }
+
+                        if (!tracers.empty())
+                                return std::make_shared<TracerMultiplexer>(std::move(tracers));
+                }
+        }
+
+        if (_param.count("tracer") && !_param["tracer"].empty())
+        {
+                mcp::json config;
+                if (_param.count("tracerConfig"))
+                        config = _param["tracerConfig"];
+
+                return createTracerByName(_param["tracer"], _er, config);
+        }
+
+        return std::make_shared<OpCode>(_er, _param);
 }

--- a/mcp/node/tracers/Tracer.hpp
+++ b/mcp/node/tracers/Tracer.hpp
@@ -3,14 +3,18 @@
 #include <libevm/VMFace.h>
 #include <libevm/Logger.h>
 #include <mcp/core/common.hpp>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace mcp
 {
-	class Tracer : public dev::eth::EVMLogger
-	{
-		friend class OpCode;
-	public:
-		explicit Tracer() {};
+        class Tracer : public dev::eth::EVMLogger
+        {
+                friend class OpCode;
+        public:
+                explicit Tracer() {};
 
 		void CaptureTxStart(uint64_t _gasLimit) override {}
 		void CaptureTxEnd(uint64_t _restGas) override {}
@@ -28,9 +32,40 @@ namespace mcp
 		void CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
 			uint64_t _gasCost, uint64_t _gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* _voidExt) override {}
 
-		virtual mcp::json GetResult() { return mcp::json::object(); }
+                virtual mcp::json GetResult() { return mcp::json::object(); }
 
-	};
+        };
 
-	std::shared_ptr<Tracer> NewTracer(mcp::json const& _param, mcp::ExecutionResult& _er);
+        class TracerMultiplexer : public Tracer
+        {
+        public:
+                using NamedTracer = std::pair<std::string, std::shared_ptr<Tracer>>;
+
+                explicit TracerMultiplexer(std::vector<NamedTracer> tracers) : m_tracers(std::move(tracers)) {}
+
+                bool empty() const { return m_tracers.empty(); }
+
+                void CaptureTxStart(uint64_t _gasLimit) override;
+                void CaptureTxEnd(uint64_t _restGas) override;
+
+                void CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to,
+                        bool _create, dev::bytes const& _input, uint64_t _gas, dev::u256 _value) override;
+                void CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted) override;
+
+                void CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to,
+                        dev::bytes const& _input, uint64_t _gas, std::shared_ptr<dev::u256> _value) override;
+                void CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted) override;
+
+                void CaptureState(uint64_t PC, dev::eth::Instruction inst,
+                        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt) override;
+                void CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
+                        uint64_t _gasCost, uint64_t _gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* _voidExt) override;
+
+                mcp::json GetResult() override;
+
+        private:
+                std::vector<NamedTracer> m_tracers;
+        };
+
+        std::shared_ptr<Tracer> NewTracer(mcp::json const& _param, mcp::ExecutionResult& _er);
 }

--- a/mcp/node/tracers/Tracer.hpp
+++ b/mcp/node/tracers/Tracer.hpp
@@ -13,35 +13,13 @@ namespace mcp
         class Tracer : public dev::eth::EVMLogger
         {
         public:
-                explicit Tracer() {};
-
-		void CaptureTxStart(uint64_t _gasLimit) override {}
-		void CaptureTxEnd(uint64_t _restGas) override {}
-
-		void CaptureStart(dev::eth::ExtVMFace const* _voidExt, dev::Address const& _from, dev::Address const& _to,
-			bool _create, dev::bytes const& _input, uint64_t _gas, dev::u256 _value) override {}
-		void CaptureEnd(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted) override {}
-
-		void CaptureEnter(dev::eth::Instruction _inst, dev::Address const& _from, dev::Address const& _to, 
-			dev::bytes const& _input, uint64_t _gas, std::shared_ptr<dev::u256> _value) override {}
-		void CaptureExit(dev::bytes const& _output, uint64_t _gasUsed, mcp::TransactionException const _excepted) override {}
-
-		void CaptureState(uint64_t PC, dev::eth::Instruction inst,
-			uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt) override {}
-		void CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
-			uint64_t _gasCost, uint64_t _gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* _voidExt) override {}
-
-                virtual mcp::json GetResult() { return mcp::json::object(); }
-
-        };
-
-        class TracerHookSet : public Tracer
-        {
-        public:
                 using NamedTracer = std::pair<std::string, std::shared_ptr<Tracer>>;
 
+                explicit Tracer() = default;
+
                 void addTracer(std::string name, std::shared_ptr<Tracer> tracer);
-                bool empty() const { return m_tracers.empty(); }
+                bool hasChildren() const { return !m_tracers.empty(); }
+                size_t childCount() const { return m_tracers.size(); }
 
                 void CaptureTxStart(uint64_t _gasLimit) override;
                 void CaptureTxEnd(uint64_t _restGas) override;
@@ -59,7 +37,10 @@ namespace mcp
                 void CaptureFault(uint64_t _PC, dev::eth::Instruction _inst,
                         uint64_t _gasCost, uint64_t _gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* _voidExt) override;
 
-                mcp::json GetResult() override;
+                virtual mcp::json GetResult();
+
+        protected:
+                std::vector<NamedTracer> const& children() const { return m_tracers; }
 
         private:
                 std::vector<NamedTracer> m_tracers;

--- a/mcp/node/tracers/Tracer.hpp
+++ b/mcp/node/tracers/Tracer.hpp
@@ -12,7 +12,6 @@ namespace mcp
 {
         class Tracer : public dev::eth::EVMLogger
         {
-                friend class OpCode;
         public:
                 explicit Tracer() {};
 

--- a/mcp/node/tracers/Tracer.hpp
+++ b/mcp/node/tracers/Tracer.hpp
@@ -35,13 +35,12 @@ namespace mcp
 
         };
 
-        class TracerMultiplexer : public Tracer
+        class TracerHookSet : public Tracer
         {
         public:
                 using NamedTracer = std::pair<std::string, std::shared_ptr<Tracer>>;
 
-                explicit TracerMultiplexer(std::vector<NamedTracer> tracers) : m_tracers(std::move(tracers)) {}
-
+                void addTracer(std::string name, std::shared_ptr<Tracer> tracer);
                 bool empty() const { return m_tracers.empty(); }
 
                 void CaptureTxStart(uint64_t _gasLimit) override;

--- a/mcp/rpc/handler.cpp
+++ b/mcp/rpc/handler.cpp
@@ -1681,6 +1681,6 @@ void mcp::rpc_handler::traceTransaction(mcp::Executive& _e, mcp::Transaction con
 	// Initialize, execute, and finalize the transaction with tracing enabled
 	_e.initialize(_t);
 	if (!_e.execute())
-		_e.go();  // This will trigger opcode logging via g_opcodeLogCallback and tracer->CaptureState
+		_e.go();  // This will trigger tracer CaptureState callbacks via the VM on-op hook
 	_e.finalize();
 }

--- a/mcp/rpc/handler.cpp
+++ b/mcp/rpc/handler.cpp
@@ -1645,11 +1645,24 @@ void mcp::rpc_handler::debug_traceTransaction(mcp::json &j_response, bool &)
 		LocalisedTransaction t = client()->localisedTransaction(txHash);
 		Block block = client()->blockByHash(t.blockHash(), true);
 		
-		// Set up tracer options from params[1] (if provided)
-		mcp::json tracerOptions;
-		if (params.size() > 1 && !params[1].is_null()) {
-			tracerOptions = params[1];
-		}
+                // Set up tracer options from params[1] (if provided)
+                mcp::json tracerOptions = mcp::json::object();
+                if (params.size() > 1 && !params[1].is_null())
+                {
+                        auto const& rawOptions = params[1];
+                        if (rawOptions.is_string())
+                        {
+                                tracerOptions["tracer"] = rawOptions.get<std::string>();
+                        }
+                        else if (rawOptions.is_array())
+                        {
+                                tracerOptions["tracers"] = rawOptions;
+                        }
+                        else
+                        {
+                                tracerOptions = rawOptions;
+                        }
+                }
 		
 		// Create execution result and tracer
 		mcp::ExecutionResult er;


### PR DESCRIPTION
## Summary
- propagate tracer instances through ExtVM construction so nested calls and creates reuse the requested logger
- drive CaptureState via the VM on-op callback instead of the global opcode logger and pass tracers to ExtVM instances created by the executive
- clarify the debug_traceTransaction helper comment about how CaptureState is triggered

## Testing
- not run (build instructions not provided in repository)


------
https://chatgpt.com/codex/tasks/task_e_68cb2bf77fac8329a69667a891db5d9f