### PR TITLE
Implement opcode tracer using interpreter VM

### DIFF
--- a/libinterpreter/VM.cpp
+++ b/libinterpreter/VM.cpp
@@ -124,6 +124,15 @@ namespace eth
 
 // Global opcode logging callback
 OpcodeLogCallback g_opcodeLogCallback;
+
+std::vector<intx::uint256> VM::stack() const
+{
+    std::vector<intx::uint256> out;
+    out.reserve(static_cast<size_t>(m_stackEnd - m_SP));
+    for (auto it = m_SP; it != m_stackEnd; ++it)
+        out.emplace_back(*it);
+    return out;
+}
 uint64_t VM::memNeed(intx::uint256 const& _offset, intx::uint256 const& _size)
 {
     return toInt63(_size ? intx::uint512(_offset) + _size : intx::uint512(0));

--- a/libinterpreter/VM.h
+++ b/libinterpreter/VM.h
@@ -14,6 +14,7 @@
 #include <boost/optional.hpp>
 #include <functional>
 #include <string>
+#include <vector>
 
 namespace dev
 {
@@ -66,6 +67,12 @@ public:
 
     // Set opcode logging callback for debugging
     void setOpcodeLogCallback(const OpcodeLogCallback& callback) { m_opcodeLogCallback = callback; }
+
+    /// Returns a copy of the current EVM stack from top (index 0) to bottom.
+    std::vector<intx::uint256> stack() const;
+
+    /// Returns a reference to the VM memory buffer.
+    bytes const& memory() const { return m_mem; }
 
     uint64_t m_io_gas = 0;
 private:

--- a/mcp/node/evm/Executive.cpp
+++ b/mcp/node/evm/Executive.cpp
@@ -1,7 +1,6 @@
 #include "Executive.hpp"
 #include "ExtVM.h"
 
-#include <libevm/LegacyVM.h>
 #include <libevm/VMFactory.h>
 #include <libinterpreter/VM.h>
 #include <mcp/common/Exceptions.h>
@@ -15,33 +14,6 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 using namespace dev::eth;
-
-namespace
-{
-	std::string dumpStackAndMemory(LegacyVM const& _vm)
-	{
-		ostringstream o;
-		o << "\n    STACK\n";
-		for (auto i : _vm.stack())
-			o << (h256)i << "\n";
-		o << "    MEMORY\n"
-			<< ((_vm.memory().size() > 1000) ? " mem size greater than 1000 bytes " :
-				memDump(_vm.memory()));
-		return o.str();
-	};
-
-	std::string dumpStorage(ExtVM const& _ext)
-	{
-		ostringstream o;
-		o << "    STORAGE\n";
-		for (auto const& i : _ext.state().storage(_ext.myAddress))
-			o << showbase << hex << i.second.first << ": " << i.second.second << "\n";
-		return o.str();
-	};
-
-}  // namespace
-
-
 
 mcp::Executive::Executive(chain_state& io_s, Block const& _block, unsigned _txIndex, chain const& _bc, unsigned _level, std::shared_ptr<EVMLogger> _tracer)
 	: m_s(createIntermediateState(io_s, _block, _txIndex, _bc)),
@@ -339,16 +311,16 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
             // Set up opcode logging callback for debugging - connect both BOOST_LOG and shared_ptr tracer
             g_opcodeLogCallback = OpcodeLogCallback([this](uint64_t pc, Instruction op, const std::string& opName, const VM* vm) {
                 // Log to BOOST_LOG for debugging output
-                BOOST_LOG(m_log.trace) << "EVM Opcode: TxHash=" << m_t.sha3().hexPrefixed() 
-                                      << " PC=" << pc << " OP=" << opName 
+                BOOST_LOG(m_log.trace) << "EVM Opcode: TxHash=" << m_t.sha3().hexPrefixed()
+                                      << " PC=" << pc << " OP=" << opName
                                       << " (0x" << std::hex << static_cast<int>(op) << std::dec << ")";
-                
+
                 // Connect to shared_ptr tracer for structured tracing
                 if (m_tracer && m_ext) {
-                    // Call CaptureState with nullptr for VMFace since we don't have access to it here
-                    // The tracer should handle this gracefully
+                    // Forward the VM pointer when available so tracers can inspect runtime state
                     try {
-                        m_tracer->CaptureState(pc, op, 0, static_cast<uint64_t>(m_gas), nullptr, m_ext.get());
+                        dev::eth::VMFace const* vmFace = dynamic_cast<dev::eth::VMFace const*>(vm);
+                        m_tracer->CaptureState(pc, op, 0, static_cast<uint64_t>(m_gas), vmFace, m_ext.get());
                     } catch (...) {
                         // Protect against tracer failures affecting VM execution
                         BOOST_LOG(m_log.debug) << "Tracer CaptureState failed for PC=" << pc << " OP=" << opName;

--- a/mcp/node/tracers/OpCode.cpp
+++ b/mcp/node/tracers/OpCode.cpp
@@ -1,17 +1,34 @@
 #include "OpCode.hpp"
-#include <libevm/LegacyVM.h>
+#include <libinterpreter/VM.h>
 #include <mcp/node/evm/ExtVM.h>
+#include <array>
+#include <cstdint>
+
+namespace
+{
+dev::u256 intxToU256(intx::uint256 const& value)
+{
+    auto bytes = intx::be::store<std::array<uint8_t, 32>>(value);
+    dev::u256 result = 0;
+    for (uint8_t byte : bytes)
+    {
+        result <<= 8;
+        result |= dev::u256(byte);
+    }
+    return result;
+}
+}
 
 using namespace dev::eth;
 void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
-	uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
+        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
 {
 	// check if already accumulated the specified number of logs
 	if (m_options.limit != 0 && m_options.limit <= m_outValue.size())
 		return;
 
-	ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
-	auto vm = dynamic_cast<LegacyVM const*>(_vm);
+        ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
+        auto vm = dynamic_cast<dev::eth::VM const*>(_vm);
 
 	mcp::json r = mcp::json::object();
 
@@ -27,18 +44,18 @@ void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
 	//	r["memexpand"] = toString(newMemSize);
 
 	mcp::json stack = mcp::json::array();
-	if (vm && !m_options.disableStack)
-	{
-		//mcp::log m_log = { mcp::log("vm") };
-		// Try extracting information about the stack from the VM is supported.
-		for (auto const& i : vm->stack())
-		{
-			//LOG(m_log.info) << i << " : " << toCompactHexPrefixed(i, 1);
-			stack.push_back(toCompactHexPrefixedTrim(i));
-		}
+        if (vm && !m_options.disableStack)
+        {
+                //mcp::log m_log = { mcp::log("vm") };
+                // Try extracting information about the stack from the VM is supported.
+                for (auto const& i : vm->stack())
+                {
+                        //LOG(m_log.info) << i << " : " << toCompactHexPrefixed(i, 1);
+                        stack.push_back(toCompactHexPrefixedTrim(intxToU256(i)));
+                }
 
-		r["stack"] = stack;
-	}
+                r["stack"] = stack;
+        }
 
 	//bool newContext = false;
 	//Instruction lastInst = Instruction::STOP;
@@ -69,9 +86,9 @@ void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
 	//	m_lastInst.resize(ext.depth + 1);
 	//}
 
-	if (vm)
-	{
-		bytes const& memory = vm->memory();
+        if (vm)
+        {
+                bytes const& memory = vm->memory();
 
 		mcp::json memJson(mcp::json::array());
 		if (m_options.enableMemory)


### PR DESCRIPTION
## Summary
- expose stack and memory accessors on the interpreter VM to support tracing
- update the opcode tracer to use the interpreter VM instead of the legacy VM implementation
- adjust the executive opcode callback to forward the active VM to tracers and drop unused legacy helpers

## Testing
- not run (environment lacks required submodule dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68cc96c10de48329bab5eb7371445df3