### PR TITLE
Add opcode tracing support for debug_traceTransaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,10 +279,14 @@ add_library (node
 	mcp/node/arrival.cpp
 	mcp/node/arrival.hpp
 	mcp/node/arrival.hpp
-	mcp/node/debug.cpp
-	mcp/node/debug.hpp
-	mcp/node/transaction_queue.cpp
-	mcp/node/transaction_queue.hpp
+        mcp/node/debug.cpp
+        mcp/node/debug.hpp
+        mcp/node/tracers/Tracer.cpp
+        mcp/node/tracers/Tracer.hpp
+        mcp/node/tracers/OPCodeTracer.cpp
+        mcp/node/tracers/OPCodeTracer.hpp
+        mcp/node/transaction_queue.cpp
+        mcp/node/transaction_queue.hpp
 	mcp/node/common.cpp
 	mcp/node/common.hpp
 	mcp/node/approve_queue.cpp

--- a/libinterpreter/VM.cpp
+++ b/libinterpreter/VM.cpp
@@ -4,6 +4,8 @@
 #include "interpreter.h"
 #include "VM.h"
 
+#include <mcp/node/tracers/Tracer.hpp>
+
 //#include <aleth/version.h>
 
 namespace
@@ -154,6 +156,39 @@ uint64_t VM::decodeJumpvDest(const byte* const _code, uint64_t& _pc, byte _voff)
 
     _pc += 1 + n * 2;               // adust inout _pc to opcode after table
     return dest;
+}
+
+
+void VM::onOperation()
+{
+    using namespace mcp::tracing;
+
+    auto* tracer = TracerManager::currentTracer();
+    if (!tracer)
+        return;
+
+    auto const* context = TracerManager::currentContext();
+    if (!context)
+        return;
+
+    OperationState state;
+    state.step = m_nSteps++;
+    state.pc = m_PC;
+    state.opcode = m_OP;
+    state.gasCost = dev::bigint(m_runGas);
+    state.gasLeft = dev::bigint(m_io_gas);
+    state.newMemorySize = dev::bigint(m_newMemSize);
+
+    if (TracerManager::tracerNeedsMemory())
+        state.memory = {m_mem.data(), m_mem.size()};
+
+    if (TracerManager::tracerNeedsStack())
+    {
+        state.stackTop = m_SP;
+        state.stackSize = stackSize();
+    }
+
+    tracer->captureState(state, *context);
 }
 
 

--- a/libinterpreter/VM.h
+++ b/libinterpreter/VM.h
@@ -133,7 +133,7 @@ private:
     std::vector<uint64_t> m_jumpDests;
     int64_t verifyJumpDest(intx::uint256 const& _dest, bool _throw = true);
 
-    void onOperation() {}
+    void onOperation();
     void adjustStack(int _removed, int _added);
     uint64_t gasForMem(intx::uint512 const& _size);
     void updateIOGas();

--- a/mcp/node/evm/Executive.cpp
+++ b/mcp/node/evm/Executive.cpp
@@ -5,6 +5,7 @@
 #include <libevm/VMFactory.h>
 #include <mcp/common/Exceptions.h>
 #include <mcp/common/stopwatch.hpp>
+#include <mcp/node/tracers/Tracer.hpp>
 
 #include <numeric>
 
@@ -306,6 +307,7 @@ bool mcp::Executive::go(dev::eth::OnOpFunc const& _onOp)
 	//mcp::stopwatch_guard sw("Executive:go");
     if (m_ext)
     {
+        mcp::tracing::ContextGuard tracerContext(m_ext.get(), static_cast<unsigned>(m_ext->depth));
 #if ETH_TIMED_EXECUTIONS
         Timer t;
 #endif

--- a/mcp/node/tracers/OPCodeTracer.cpp
+++ b/mcp/node/tracers/OPCodeTracer.cpp
@@ -1,0 +1,191 @@
+#include "OPCodeTracer.hpp"
+
+#include "../evm/ExtVM.h"
+
+#include <libdevcore/CommonData.h>
+#include <libevm/Instruction.h>
+#include <libevm/InstructionInfo.h>
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include <evmc/evmc.h>
+
+namespace mcp
+{
+namespace tracing
+{
+namespace
+{
+using dev::eth::Instruction;
+
+bool changesMemory(Instruction inst)
+{
+    switch (inst)
+    {
+    case Instruction::MSTORE:
+    case Instruction::MSTORE8:
+    case Instruction::MLOAD:
+    case Instruction::CREATE:
+    case Instruction::CALL:
+    case Instruction::CALLCODE:
+    case Instruction::SHA3:
+    case Instruction::CALLDATACOPY:
+    case Instruction::CODECOPY:
+    case Instruction::EXTCODECOPY:
+    case Instruction::DELEGATECALL:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool changesStorage(Instruction inst)
+{
+    return inst == Instruction::SSTORE;
+}
+
+dev::h256 toH256(intx::uint256 const& value)
+{
+    evmc_uint256be be = intx::be::store<evmc_uint256be>(value);
+    dev::h256 out;
+    std::memcpy(out.data(), be.bytes, sizeof(be.bytes));
+    return out;
+}
+}
+
+OPCodeTracer::OPCodeTracer(Options options)
+  : m_options(options), m_trace(mcp::json::array())
+{
+}
+
+OPCodeTracer::Options OPCodeTracer::fromJson(mcp::json const& json)
+{
+    Options opts;
+    if (!json.is_object())
+        return opts;
+
+    if (json.contains("disableStorage"))
+        opts.disableStorage = json["disableStorage"].get<bool>();
+    if (json.contains("disableMemory"))
+        opts.disableMemory = json["disableMemory"].get<bool>();
+    if (json.contains("disableStack"))
+        opts.disableStack = json["disableStack"].get<bool>();
+    if (json.contains("full_storage"))
+        opts.fullStorage = json["full_storage"].get<bool>();
+    return opts;
+}
+
+bool OPCodeTracer::needsStack() const
+{
+    return !m_options.disableStack;
+}
+
+bool OPCodeTracer::needsMemory() const
+{
+    return !m_options.disableMemory;
+}
+
+void OPCodeTracer::captureState(OperationState const& state, ExecutionContext const& context)
+{
+    mcp::json entry = mcp::json::object();
+
+    if (!m_options.disableStack && state.stackTop)
+    {
+        mcp::json stack = mcp::json::array();
+        for (size_t i = 0; i < state.stackSize; ++i)
+        {
+            stack.push_back(toCompactHex(toH256(state.stackTop[i]), 32));
+        }
+        entry["stack"] = stack;
+    }
+
+    bool newContext = false;
+    Instruction lastInst = Instruction::STOP;
+
+    unsigned depth = context.depth;
+    if (depth == 0)
+        depth = 1;
+
+    if (m_lastInst.size() == depth - 1)
+    {
+        m_lastInst.push_back(state.opcode);
+        newContext = true;
+    }
+    else if (!m_lastInst.empty() && m_lastInst.size() == depth)
+    {
+        lastInst = m_lastInst.back();
+        m_lastInst.back() = state.opcode;
+    }
+    else if (!m_lastInst.empty() && m_lastInst.size() == depth + 1)
+    {
+        m_lastInst.pop_back();
+        lastInst = m_lastInst.back();
+        m_lastInst.back() = state.opcode;
+    }
+    else
+    {
+        m_lastInst.resize(depth);
+        if (!m_lastInst.empty())
+        {
+            lastInst = m_lastInst.back();
+            m_lastInst.back() = state.opcode;
+        }
+        else
+        {
+            m_lastInst.push_back(state.opcode);
+            newContext = true;
+        }
+    }
+
+    if (!m_options.disableMemory && state.memory.data && state.memory.size > 0 &&
+        (newContext || changesMemory(lastInst)))
+    {
+        mcp::json memory = mcp::json::array();
+        for (size_t i = 0; i < state.memory.size; i += 32)
+        {
+            size_t chunkSize = std::min<size_t>(32, state.memory.size - i);
+            if (chunkSize == 32)
+            {
+                memory.push_back(toHex(dev::bytesConstRef(state.memory.data + i, chunkSize)));
+            }
+            else
+            {
+                dev::bytes temp(state.memory.data + i, state.memory.data + i + chunkSize);
+                temp.resize(32, 0);
+                memory.push_back(toHex(dev::bytesConstRef(temp.data(), temp.size())));
+            }
+        }
+        entry["memory"] = memory;
+    }
+
+    auto const* ext = dynamic_cast<mcp::ExtVM const*>(context.ext);
+    if (!m_options.disableStorage && ext &&
+        (m_options.fullStorage || newContext || changesStorage(lastInst)))
+    {
+        mcp::json storage = mcp::json::object();
+        for (auto const& item : ext->state().storage(ext->myAddress))
+        {
+            storage[toCompactHexPrefixed(item.second.first, 1)] =
+                toCompactHex(item.second.second, 32);
+        }
+        entry["storage"] = storage;
+    }
+
+    if (m_showMnemonics)
+        entry["op"] = dev::eth::instructionInfo(state.opcode).name;
+
+    entry["pc"] = dev::toString(state.pc);
+    entry["gas"] = dev::toString(state.gasLeft);
+    entry["gasCost"] = dev::toString(state.gasCost);
+    entry["depth"] = dev::toString(depth);
+    if (state.newMemorySize != 0)
+        entry["memexpand"] = dev::toString(state.newMemorySize);
+
+    m_trace.push_back(entry);
+}
+
+}  // namespace tracing
+}  // namespace mcp
+

--- a/mcp/node/tracers/OPCodeTracer.hpp
+++ b/mcp/node/tracers/OPCodeTracer.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "Tracer.hpp"
+
+#include <mcp/common/json.hpp>
+
+namespace mcp
+{
+namespace tracing
+{
+class OPCodeTracer : public Tracer
+{
+public:
+    struct Options
+    {
+        bool disableStorage = false;
+        bool disableMemory = false;
+        bool disableStack = false;
+        bool fullStorage = false;
+    };
+
+    explicit OPCodeTracer(Options options = Options{});
+
+    void setShowMnemonics(bool value) { m_showMnemonics = value; }
+
+    static Options fromJson(mcp::json const& json);
+
+    mcp::json const& logs() const { return m_trace; }
+
+    bool needsStack() const override;
+    bool needsMemory() const override;
+
+    void captureState(OperationState const& state, ExecutionContext const& context) override;
+
+private:
+    Options m_options;
+    bool m_showMnemonics = false;
+    std::vector<dev::eth::Instruction> m_lastInst;
+    mcp::json m_trace;
+};
+
+}  // namespace tracing
+}  // namespace mcp
+

--- a/mcp/node/tracers/Tracer.cpp
+++ b/mcp/node/tracers/Tracer.cpp
@@ -1,0 +1,94 @@
+#include "Tracer.hpp"
+
+#include <vector>
+
+namespace mcp
+{
+namespace tracing
+{
+namespace
+{
+thread_local Tracer* s_currentTracer = nullptr;
+thread_local std::vector<ExecutionContext> s_contextStack;
+}
+
+Tracer* TracerManager::setTracer(Tracer* tracer)
+{
+    Tracer* previous = s_currentTracer;
+    if (s_currentTracer != tracer)
+    {
+        s_contextStack.clear();
+        s_currentTracer = tracer;
+    }
+    return previous;
+}
+
+Tracer* TracerManager::currentTracer()
+{
+    return s_currentTracer;
+}
+
+bool TracerManager::pushContext(dev::eth::ExtVMFace const* ext, unsigned depth)
+{
+    auto* tracer = s_currentTracer;
+    if (!tracer || !ext)
+        return false;
+
+    s_contextStack.push_back({ext, depth});
+    tracer->onExecutionStart(s_contextStack.back());
+    return true;
+}
+
+void TracerManager::popContext()
+{
+    if (!s_currentTracer || s_contextStack.empty())
+        return;
+
+    auto ctx = s_contextStack.back();
+    s_currentTracer->onExecutionEnd(ctx);
+    s_contextStack.pop_back();
+}
+
+ExecutionContext const* TracerManager::currentContext()
+{
+    if (s_contextStack.empty())
+        return nullptr;
+    return &s_contextStack.back();
+}
+
+bool TracerManager::tracerNeedsStack()
+{
+    auto* tracer = s_currentTracer;
+    return tracer && tracer->needsStack();
+}
+
+bool TracerManager::tracerNeedsMemory()
+{
+    auto* tracer = s_currentTracer;
+    return tracer && tracer->needsMemory();
+}
+
+ScopedTracer::ScopedTracer(Tracer* tracer)
+  : m_previous(TracerManager::setTracer(tracer))
+{
+}
+
+ScopedTracer::~ScopedTracer()
+{
+    TracerManager::setTracer(m_previous);
+}
+
+ContextGuard::ContextGuard(dev::eth::ExtVMFace const* ext, unsigned depth)
+{
+    m_active = TracerManager::pushContext(ext, depth);
+}
+
+ContextGuard::~ContextGuard()
+{
+    if (m_active)
+        TracerManager::popContext();
+}
+
+}  // namespace tracing
+}  // namespace mcp
+

--- a/mcp/node/tracers/Tracer.hpp
+++ b/mcp/node/tracers/Tracer.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <libdevcore/Common.h>
+#include <libevm/ExtVMFace.h>
+#include <libevm/Instruction.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <intx/intx.hpp>
+
+namespace mcp
+{
+namespace tracing
+{
+struct MemoryView
+{
+    const uint8_t* data = nullptr;
+    size_t size = 0;
+};
+
+struct OperationState
+{
+    uint64_t step = 0;
+    uint64_t pc = 0;
+    dev::eth::Instruction opcode = dev::eth::Instruction::STOP;
+    dev::bigint gasCost = 0;
+    dev::bigint gasLeft = 0;
+    dev::bigint newMemorySize = 0;
+    MemoryView memory;
+    intx::uint256 const* stackTop = nullptr;
+    size_t stackSize = 0;
+};
+
+struct ExecutionContext
+{
+    dev::eth::ExtVMFace const* ext = nullptr;
+    unsigned depth = 0;
+};
+
+class Tracer
+{
+public:
+    virtual ~Tracer() = default;
+
+    virtual bool needsStack() const { return true; }
+    virtual bool needsMemory() const { return true; }
+
+    virtual void onExecutionStart(ExecutionContext const&) {}
+    virtual void onExecutionEnd(ExecutionContext const&) {}
+
+    virtual void captureState(OperationState const&, ExecutionContext const&) = 0;
+};
+
+class TracerManager
+{
+public:
+    static Tracer* setTracer(Tracer* tracer);
+    static Tracer* currentTracer();
+
+    static bool pushContext(dev::eth::ExtVMFace const* ext, unsigned depth);
+    static void popContext();
+    static ExecutionContext const* currentContext();
+
+    static bool tracerNeedsStack();
+    static bool tracerNeedsMemory();
+};
+
+class ScopedTracer
+{
+public:
+    explicit ScopedTracer(Tracer* tracer);
+    ~ScopedTracer();
+
+    ScopedTracer(ScopedTracer const&) = delete;
+    ScopedTracer& operator=(ScopedTracer const&) = delete;
+
+private:
+    Tracer* m_previous;
+};
+
+class ContextGuard
+{
+public:
+    ContextGuard(dev::eth::ExtVMFace const* ext, unsigned depth);
+    ~ContextGuard();
+
+    ContextGuard(ContextGuard const&) = delete;
+    ContextGuard& operator=(ContextGuard const&) = delete;
+
+private:
+    bool m_active = false;
+};
+
+}  // namespace tracing
+}  // namespace mcp
+

--- a/mcp/rpc/handler.cpp
+++ b/mcp/rpc/handler.cpp
@@ -5,6 +5,7 @@
 #include <mcp/core/param.hpp>
 #include <mcp/common/pwd.hpp>
 #include <mcp/node/evm/Executive.hpp>
+#include <mcp/node/tracers/OPCodeTracer.hpp>
 
 mcp::rpc_handler::rpc_handler(mcp::rpc &rpc_a, std::string const &body_a, std::function<void(mcp::json const &)> const &response_a, int m_cap) : body(body_a),
 																																				 rpc(rpc_a),
@@ -69,7 +70,7 @@ mcp::rpc_handler::rpc_handler(mcp::rpc &rpc_a, std::string const &body_a, std::f
 	m_ethRpcMethods["eth_accounts"] = &mcp::rpc_handler::eth_accounts;
 	m_ethRpcMethods["eth_sign"] = &mcp::rpc_handler::eth_sign;
 	m_ethRpcMethods["eth_signTransaction"] = &mcp::rpc_handler::eth_signTransaction;
-	//m_ethRpcMethods["debug_traceTransaction"] = &mcp::rpc_handler::debug_traceTransaction;
+    m_ethRpcMethods["debug_traceTransaction"] = &mcp::rpc_handler::debug_traceTransaction;
 	//m_ethRpcMethods["debug_storageRangeAt"] = &mcp::rpc_handler::debug_storageRangeAt;
 
 	m_ethRpcMethods["personal_importRawKey"] = &mcp::rpc_handler::personal_importRawKey;
@@ -1188,82 +1189,69 @@ void mcp::rpc_handler::eth_getLogs(mcp::json &j_response, bool &)
 	j_response["result"] = toJson(ret);
 }
 
-//void mcp::rpc_handler::debug_traceTransaction(mcp::json &j_response, bool &)
-//{
-//	
-//	std::string hash_text = params[0];
-//	dev::h256 hash;
-//	hash = jsToHash(hash_text);
-//
-//	mcp::db::db_transaction transaction(m_store.create_transaction());
-//	auto _t = m_cache->transaction_get(transaction, hash);
-//	auto td = m_cache->transaction_address_get(transaction, hash);
-//
-//	if (_t == nullptr || td == nullptr)
-//	{
-//		BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Invalid Hash"));
-//	}
-//
-//	dev::eth::McInfo mc_info;
-//	if (!m_chain->get_mc_info_from_block_hash(transaction, m_cache, td->blockHash, mc_info))
-//	{
-//		BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Invalid Mci"));
-//	}
-//	mcp::json options;
-//	options["disableStorage"] = true;
-//	options["disableMemory"] = false;
-//	options["disableStack"] = false;
-//	options["full_storage"] = false;
-//
-//	mcp::json options_json = params[1];
-//	if (options_json.count("disableStorage"))
-//		options["disableStorage"] = options_json["disableStorage"];
-//	if (options_json.count("disableMemory"))
-//		options["disableMemory"] = options_json["disableMemory"];
-//	if (options_json.count("disableStack"))
-//		options["disableStack"] = options_json["disableStack"];
-//	if (options_json.count("full_storage"))
-//		options["full_storage"] = options_json["full_storage"];
-//
-//	try
-//	{
-//		dev::eth::EnvInfo env(transaction, m_store, m_cache, mc_info, mcp::chain_id);
-//		auto block(m_cache->block_get(transaction, td->blockHash));
-//		assert_x(block);
-//		chain_state c_state(transaction, 0, m_store, m_chain, m_cache);
-//		std::vector<h256> accout_state_hashs;
-//		if(!m_store.transaction_previous_account_state_get(transaction, hash, accout_state_hashs))
-//		{
-//			BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Invalid Hash"));
-//		}
-//		c_state.ts = *_t;
-//		c_state.set_defalut_account_state(accout_state_hashs);
-//
-//		//c_state should be used after set_defalut_account_state. Otherwise, account_state will be abnormal.
-//		if (!_t->isCreation() && !c_state.addressHasCode(_t->receiveAddress()))
-//		{
-//			j_response["return_value"] = "Only contract transcation can debug.";
-//			return;
-//		}
-//		mcp::ExecutionResult er;
-//		std::list<std::shared_ptr<mcp::trace>> traces;
-//		mcp::Executive e(c_state, env, traces);
-//		e.setResultRecipient(er);
-//
-//		mcp::json trace = m_chain->traceTransaction(e, *_t, options);
-//		j_response["return_value"] = toHexPrefixed(er.output);
-//		j_response["struct_logs"] = trace;
-//	}
-//	catch (Exception const &_e)
-//	{
-//		BOOST_THROW_EXCEPTION(RPC_Error_InternalError("Unexpected exception in VM. There may be a bug in this implementation."));
-//	}
-//	catch (std::exception const &_e)
-//	{
-//		BOOST_THROW_EXCEPTION(RPC_Error_InternalError("Unknown Error"));
-//	}
-//}
-//
+void mcp::rpc_handler::debug_traceTransaction(mcp::json &j_response, bool &)
+{
+        if (!params.is_array() || params.empty())
+        {
+                BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Missing parameters"));
+        }
+
+        if (!mcp::isH256(params[0]))
+        {
+                BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Invalid Hash"));
+        }
+
+        dev::h256 hash = jsToHash(params[0]);
+
+        mcp::db::db_transaction transaction(m_store.create_transaction());
+        auto tx = m_cache->transaction_get(transaction, hash);
+        auto txMeta = m_cache->transaction_address_get(transaction, hash);
+
+        if (!tx || !txMeta)
+        {
+                BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Invalid Hash"));
+        }
+
+        dev::eth::McInfo mc_info;
+        if (!m_chain->get_mc_info_from_block_hash(transaction, m_cache, txMeta->blockHash, mc_info))
+        {
+                BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Invalid Mci"));
+        }
+
+        mcp::tracing::OPCodeTracer::Options options;
+        if (params.size() > 1 && params[1].is_object())
+                options = mcp::tracing::OPCodeTracer::fromJson(params[1]);
+
+        try
+        {
+                dev::eth::EnvInfo env(transaction, m_store, m_cache, mc_info, mcp::chainID());
+                chain_state c_state(transaction, 0, m_store, m_chain, m_cache);
+
+                if (!tx->isCreation() && !c_state.addressHasCode(tx->receiveAddress()))
+                {
+                        j_response["return_value"] = "0x";
+                        j_response["struct_logs"] = mcp::json::array();
+                        return;
+                }
+
+                mcp::tracing::OPCodeTracer tracer(options);
+                tracer.setShowMnemonics(true);
+                mcp::tracing::ScopedTracer tracerScope(&tracer);
+
+                auto execution = c_state.execute(env, Permanence::Reverted, *tx, dev::eth::OnOpFunc());
+                j_response["return_value"] = toHexPrefixed(execution.first.output);
+                j_response["struct_logs"] = tracer.logs();
+        }
+        catch (Exception const &_e)
+        {
+                BOOST_THROW_EXCEPTION(RPC_Error_InternalError("Unexpected exception in VM. There may be a bug in this implementation."));
+        }
+        catch (std::exception const &_e)
+        {
+                BOOST_THROW_EXCEPTION(RPC_Error_InternalError("Unknown Error"));
+        }
+}
+
 //void mcp::rpc_handler::debug_storageRangeAt(mcp::json &j_response, bool &)
 //{
 //	//this should be a json object, not an array

--- a/mcp/rpc/handler.hpp
+++ b/mcp/rpc/handler.hpp
@@ -70,7 +70,7 @@ namespace mcp
 		void eth_accounts(mcp::json & j_response, bool & async);
 		void eth_sign(mcp::json & j_response, bool & async);
 		void eth_signTransaction(mcp::json & j_response, bool & async);
-		//void debug_traceTransaction(mcp::json & j_response, bool & async);
+                void debug_traceTransaction(mcp::json & j_response, bool & async);
 		//void debug_storageRangeAt(mcp::json & j_response, bool & async);
 		// related to personal
 		void personal_importRawKey(mcp::json & j_response, bool & async);


### PR DESCRIPTION
## Summary
- add a tracer framework that hooks into the interpreter to expose opcode execution state
- implement an OPCodeTracer and wire it into debug_traceTransaction to return struct logs
- register the RPC method and update the build configuration to compile the new tracer sources

## Testing
- cmake -S . -B build *(fails: missing Boost 1.81.0 headers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc5f2887c8329aaa30860eec0bd2b