### PR TITLE
Add opcode tracer support for debug_traceTransaction

### DIFF
--- a/libinterpreter/VM.cpp
+++ b/libinterpreter/VM.cpp
@@ -360,6 +360,15 @@ owning_bytes_ref VM::exec(const evmc_host_interface* _host, evmc_host_context* _
     return std::move(m_output);
 }
 
+std::vector<intx::uint256> VM::stackIntx() const
+{
+    std::vector<intx::uint256> values;
+    values.reserve(static_cast<size_t>(m_stackEnd - m_SP));
+    for (auto it = m_SP; it != m_stackEnd; ++it)
+        values.push_back(*it);
+    return values;
+}
+
 //
 // main interpreter loop and switch
 //

--- a/libinterpreter/VM.h
+++ b/libinterpreter/VM.h
@@ -14,6 +14,7 @@
 #include <boost/optional.hpp>
 #include <functional>
 #include <string>
+#include <vector>
 
 namespace dev
 {
@@ -63,6 +64,12 @@ public:
 
     owning_bytes_ref exec(const evmc_host_interface* _host, evmc_host_context* _context,
         evmc_revision _rev, const evmc_message* _msg, uint8_t const* _code, size_t _codeSize);
+
+    /// Expose execution context for tracers.
+    const bytes& memory() const { return m_mem; }
+    std::vector<intx::uint256> stackIntx() const;
+    uint64_t gasLeft() const { return m_io_gas; }
+    uint64_t currentGasCost() const { return m_runGas; }
 
     // Set opcode logging callback for debugging
     void setOpcodeLogCallback(const OpcodeLogCallback& callback) { m_opcodeLogCallback = callback; }

--- a/libinterpreter/VM.h
+++ b/libinterpreter/VM.h
@@ -49,8 +49,8 @@ struct VMSchedule
     static constexpr int64_t callSelfGas = 40;
 };
 
-// Callback type for logging opcodes during execution with enhanced context
-using OpcodeLogCallback = std::function<void(uint64_t pc, Instruction op, const std::string& opName, const VM* vm)>;
+// Callback type for logging opcodes during execution.
+using OpcodeLogCallback = std::function<void(uint64_t pc, Instruction op, const std::string& opName)>;
 
 // Global callback for opcode logging - can be set by Executive
 extern OpcodeLogCallback g_opcodeLogCallback;
@@ -156,12 +156,15 @@ private:
 
     void onOperation() {
         // Try instance callback first, then global callback with VM context
-        if (m_opcodeLogCallback) {
+        if (m_opcodeLogCallback)
+        {
             std::string opName = getInstructionName(m_OP);
-            m_opcodeLogCallback(m_PC, m_OP, opName, this);
-        } else if (g_opcodeLogCallback) {
+            m_opcodeLogCallback(m_PC, m_OP, opName);
+        }
+        else if (g_opcodeLogCallback)
+        {
             std::string opName = getInstructionName(m_OP);
-            g_opcodeLogCallback(m_PC, m_OP, opName, this);
+            g_opcodeLogCallback(m_PC, m_OP, opName);
         }
     }
     void adjustStack(int _removed, int _added);

--- a/mcp/node/evm/Executive.cpp
+++ b/mcp/node/evm/Executive.cpp
@@ -8,8 +8,10 @@
 #include <mcp/common/stopwatch.hpp>
 #include <mcp/core/param.hpp>
 #include <mcp/node/chain.hpp>
+#include <mcp/node/tracers/Tracer.hpp>
 #include <numeric>
 #include <iomanip>
+#include <limits>
 
 using namespace std;
 using namespace dev;
@@ -339,21 +341,38 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
             // Set up opcode logging callback for debugging - connect both BOOST_LOG and shared_ptr tracer
             g_opcodeLogCallback = OpcodeLogCallback([this](uint64_t pc, Instruction op, const std::string& opName, const VM* vm) {
                 // Log to BOOST_LOG for debugging output
-                BOOST_LOG(m_log.trace) << "EVM Opcode: TxHash=" << m_t.sha3().hexPrefixed() 
-                                      << " PC=" << pc << " OP=" << opName 
+                BOOST_LOG(m_log.trace) << "EVM Opcode: TxHash=" << m_t.sha3().hexPrefixed()
+                                      << " PC=" << pc << " OP=" << opName
                                       << " (0x" << std::hex << static_cast<int>(op) << std::dec << ")";
-                
-                // Connect to shared_ptr tracer for structured tracing
-                if (m_tracer && m_ext) {
-                    // Call CaptureState with nullptr for VMFace since we don't have access to it here
-                    // The tracer should handle this gracefully
-                    try {
-                        m_tracer->CaptureState(pc, op, 0, static_cast<uint64_t>(m_gas), nullptr, m_ext.get());
-                    } catch (...) {
-                        // Protect against tracer failures affecting VM execution
+
+                auto tracerPtr = std::dynamic_pointer_cast<mcp::Tracer>(m_tracer);
+                if (tracerPtr)
+                    tracerPtr->SetCurrentVM(vm);
+
+                uint64_t gasCost = vm ? vm->currentGasCost() : 0;
+                uint64_t gasLeft = 0;
+                if (vm)
+                    gasLeft = vm->gasLeft();
+                else
+                {
+                    static const u256 maxGas64 = u256(std::numeric_limits<uint64_t>::max());
+                    gasLeft = m_gas > maxGas64 ? std::numeric_limits<uint64_t>::max() : m_gas.convert_to<uint64_t>();
+                }
+
+                if (m_tracer && m_ext)
+                {
+                    try
+                    {
+                        m_tracer->CaptureState(pc, op, gasCost, gasLeft, nullptr, m_ext.get());
+                    }
+                    catch (...)
+                    {
                         BOOST_LOG(m_log.debug) << "Tracer CaptureState failed for PC=" << pc << " OP=" << opName;
                     }
                 }
+
+                if (tracerPtr)
+                    tracerPtr->SetCurrentVM(nullptr);
             });
 
             // Create VM instance. Force Interpreter if tracing requested.

--- a/mcp/node/evm/Executive.cpp
+++ b/mcp/node/evm/Executive.cpp
@@ -310,8 +310,11 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
 			//mcp::uint256_t start_gas_used = gasUsed();
 			//int64_t start_refunds = m_ext->sub.refunds;
 
-            // Set up opcode logging callback for debugging - connect both BOOST_LOG and shared_ptr tracer
-            g_opcodeLogCallback = OpcodeLogCallback([this](uint64_t pc, Instruction op, const std::string& opName, const VM* vm) {
+            // Set up opcode logging callback for debugging with interpreter context
+            auto vm = VMFactory::create();
+            dev::eth::VM const* interpreterVm = dynamic_cast<dev::eth::VM*>(vm.get());
+
+            g_opcodeLogCallback = OpcodeLogCallback([this, interpreterVm](uint64_t pc, Instruction op, const std::string& opName) {
                 // Log to BOOST_LOG for debugging output
                 BOOST_LOG(m_log.trace) << "EVM Opcode: TxHash=" << m_t.sha3().hexPrefixed()
                                       << " PC=" << pc << " OP=" << opName
@@ -319,12 +322,12 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
 
                 auto tracerPtr = std::dynamic_pointer_cast<mcp::Tracer>(m_tracer);
                 if (tracerPtr)
-                    tracerPtr->SetCurrentVM(vm);
+                    tracerPtr->SetCurrentVM(interpreterVm);
 
-                uint64_t gasCost = vm ? vm->currentGasCost() : 0;
+                uint64_t gasCost = interpreterVm ? interpreterVm->currentGasCost() : 0;
                 uint64_t gasLeft = 0;
-                if (vm)
-                    gasLeft = vm->gasLeft();
+                if (interpreterVm)
+                    gasLeft = interpreterVm->gasLeft();
                 else
                 {
                     static const u256 maxGas64 = u256(std::numeric_limits<uint64_t>::max());
@@ -335,7 +338,7 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
                 {
                     try
                     {
-                        m_tracer->CaptureState(pc, op, gasCost, gasLeft, nullptr, m_ext.get());
+                        m_tracer->CaptureState(pc, op, gasCost, gasLeft, interpreterVm, m_ext.get());
                     }
                     catch (...)
                     {
@@ -346,9 +349,6 @@ bool mcp::Executive::go(/*dev::eth::OnOpFunc const& _onOp*/)
                 if (tracerPtr)
                     tracerPtr->SetCurrentVM(nullptr);
             });
-
-            // Create VM instance. Force Interpreter if tracing requested.
-            auto vm = VMFactory::create();
             if (m_isCreation)
             {
 				m_output = vm->exec(m_gas, *m_ext, m_tracer/*, _onOp*/);

--- a/mcp/node/evm/Executive.cpp
+++ b/mcp/node/evm/Executive.cpp
@@ -1,7 +1,6 @@
 #include "Executive.hpp"
 #include "ExtVM.h"
 
-#include <libevm/LegacyVM.h>
 #include <libevm/VMFactory.h>
 #include <libinterpreter/VM.h>
 #include <mcp/common/Exceptions.h>
@@ -17,33 +16,6 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 using namespace dev::eth;
-
-namespace
-{
-	std::string dumpStackAndMemory(LegacyVM const& _vm)
-	{
-		ostringstream o;
-		o << "\n    STACK\n";
-		for (auto i : _vm.stack())
-			o << (h256)i << "\n";
-		o << "    MEMORY\n"
-			<< ((_vm.memory().size() > 1000) ? " mem size greater than 1000 bytes " :
-				memDump(_vm.memory()));
-		return o.str();
-	};
-
-	std::string dumpStorage(ExtVM const& _ext)
-	{
-		ostringstream o;
-		o << "    STORAGE\n";
-		for (auto const& i : _ext.state().storage(_ext.myAddress))
-			o << showbase << hex << i.second.first << ": " << i.second.second << "\n";
-		return o.str();
-	};
-
-}  // namespace
-
-
 
 mcp::Executive::Executive(chain_state& io_s, Block const& _block, unsigned _txIndex, chain const& _bc, unsigned _level, std::shared_ptr<EVMLogger> _tracer)
 	: m_s(createIntermediateState(io_s, _block, _txIndex, _bc)),

--- a/mcp/node/tracers/OpCode.cpp
+++ b/mcp/node/tracers/OpCode.cpp
@@ -2,32 +2,38 @@
 #include <libinterpreter/VM.h>
 #include <mcp/node/evm/ExtVM.h>
 #include <algorithm>
-#include <array>
-#include <iomanip>
 #include <sstream>
 
 using namespace dev::eth;
 namespace
 {
-        std::string toCompactHexFromIntx(intx::uint256 const& value)
+        std::string toCompactHexFromIntx(intx::uint256 value)
         {
-                auto bytes = intx::be::store<std::array<uint8_t, 32>>(value);
-                size_t firstNonZero = 0;
-                while (firstNonZero < bytes.size() && bytes[firstNonZero] == 0)
-                        ++firstNonZero;
-
                 std::ostringstream out;
                 out << "0x";
-                if (firstNonZero == bytes.size())
+
+                if (value == 0)
                 {
                         out << '0';
+                        return out.str();
                 }
-                else
+
+                std::string hex;
+                hex.reserve(64);
+
+                while (value != 0)
                 {
-                        out << std::hex << std::nouppercase << std::setfill('0');
-                        for (size_t i = firstNonZero; i < bytes.size(); ++i)
-                                out << std::setw(2) << static_cast<unsigned>(bytes[i]);
+                        auto nibble = static_cast<unsigned>(value & intx::uint256{0xF});
+                        hex.push_back(nibble < 10 ? static_cast<char>('0' + nibble)
+                                                  : static_cast<char>('a' + (nibble - 10)));
+                        value >>= 4;
                 }
+
+                if (hex.size() % 2 != 0)
+                        hex.push_back('0');
+
+                std::reverse(hex.begin(), hex.end());
+                out << hex;
                 return out.str();
         }
 }

--- a/mcp/node/tracers/OpCode.cpp
+++ b/mcp/node/tracers/OpCode.cpp
@@ -1,5 +1,4 @@
 #include "OpCode.hpp"
-#include <libevm/LegacyVM.h>
 #include <libinterpreter/VM.h>
 #include <mcp/node/evm/ExtVM.h>
 #include <algorithm>
@@ -34,14 +33,13 @@ namespace
 }
 
 void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
-        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
+        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* /*_vm*/, dev::eth::ExtVMFace const* voidExt)
 {
         // check if already accumulated the specified number of logs
         if (m_options.limit != 0 && m_options.limit <= m_outValue.size())
                 return;
 
         ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
-        auto legacyVm = dynamic_cast<LegacyVM const*>(_vm);
         auto interpreterVm = m_currentInterpreterVm;
 
         mcp::json r = mcp::json::object();
@@ -53,14 +51,7 @@ void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
         r["depth"] = ext.depth + 1;  // depth in standard trace is 1-based
 
         mcp::json stack = mcp::json::array();
-        if (legacyVm && !m_options.disableStack)
-        {
-                for (auto const& i : legacyVm->stack())
-                        stack.push_back(toCompactHexPrefixedTrim(i));
-
-                r["stack"] = stack;
-        }
-        else if (interpreterVm && !m_options.disableStack)
+        if (interpreterVm && !m_options.disableStack)
         {
                 for (auto const& value : interpreterVm->stackIntx())
                         stack.push_back(toCompactHexFromIntx(value));
@@ -68,22 +59,7 @@ void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
                 r["stack"] = stack;
         }
 
-        if (legacyVm)
-        {
-                bytes const& memory = legacyVm->memory();
-
-                if (m_options.enableMemory)
-                {
-                        mcp::json memJson(mcp::json::array());
-                        for (unsigned i = 0; i < memory.size(); i += 32)
-                        {
-                                bytesConstRef memRef(memory.data() + i, 32);
-                                memJson.push_back(toHex(memRef));
-                        }
-                        r["memory"] = memJson;
-                }
-        }
-        else if (interpreterVm)
+        if (interpreterVm)
         {
                 bytes const& memory = interpreterVm->memory();
 

--- a/mcp/node/tracers/OpCode.cpp
+++ b/mcp/node/tracers/OpCode.cpp
@@ -1,131 +1,145 @@
 #include "OpCode.hpp"
 #include <libevm/LegacyVM.h>
+#include <libinterpreter/VM.h>
 #include <mcp/node/evm/ExtVM.h>
+#include <algorithm>
+#include <array>
+#include <iomanip>
+#include <sstream>
 
 using namespace dev::eth;
-void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
-	uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
+namespace
 {
-	// check if already accumulated the specified number of logs
-	if (m_options.limit != 0 && m_options.limit <= m_outValue.size())
-		return;
+        std::string toCompactHexFromIntx(intx::uint256 const& value)
+        {
+                auto bytes = intx::be::store<std::array<uint8_t, 32>>(value);
+                size_t firstNonZero = 0;
+                while (firstNonZero < bytes.size() && bytes[firstNonZero] == 0)
+                        ++firstNonZero;
 
-	ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
-	auto vm = dynamic_cast<LegacyVM const*>(_vm);
+                std::ostringstream out;
+                out << "0x";
+                if (firstNonZero == bytes.size())
+                {
+                        out << '0';
+                }
+                else
+                {
+                        out << std::hex << std::nouppercase << std::setfill('0');
+                        for (size_t i = firstNonZero; i < bytes.size(); ++i)
+                                out << std::setw(2) << static_cast<unsigned>(bytes[i]);
+                }
+                return out.str();
+        }
+}
 
-	mcp::json r = mcp::json::object();
+void mcp::OpCode::CaptureState(uint64_t PC, dev::eth::Instruction inst,
+        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt)
+{
+        // check if already accumulated the specified number of logs
+        if (m_options.limit != 0 && m_options.limit <= m_outValue.size())
+                return;
 
-	r["pc"] = PC;
-	r["op"] = instructionInfo(inst).name;
-	//r["op"] = static_cast<uint8_t>(inst);
-	//if (m_showMnemonics)
-	//	r["opName"] = instructionInfo(inst).name;
-	r["gas"] = gas/*.convert_to<uint64_t>()*//*toString(gas)*/;
-	r["gasCost"] = gasCost/*.convert_to<uint64_t>()*//*toString(gasCost)*/;
-	r["depth"] = ext.depth + 1;  // depth in standard trace is 1-based
-	//if (!!newMemSize)
-	//	r["memexpand"] = toString(newMemSize);
+        ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
+        auto legacyVm = dynamic_cast<LegacyVM const*>(_vm);
+        auto interpreterVm = m_currentInterpreterVm;
 
-	mcp::json stack = mcp::json::array();
-	if (vm && !m_options.disableStack)
-	{
-		//mcp::log m_log = { mcp::log("vm") };
-		// Try extracting information about the stack from the VM is supported.
-		for (auto const& i : vm->stack())
-		{
-			//LOG(m_log.info) << i << " : " << toCompactHexPrefixed(i, 1);
-			stack.push_back(toCompactHexPrefixedTrim(i));
-		}
+        mcp::json r = mcp::json::object();
 
-		r["stack"] = stack;
-	}
+        r["pc"] = PC;
+        r["op"] = instructionInfo(inst).name;
+        r["gas"] = gas;
+        r["gasCost"] = gasCost;
+        r["depth"] = ext.depth + 1;  // depth in standard trace is 1-based
 
-	//bool newContext = false;
-	//Instruction lastInst = Instruction::STOP;
+        mcp::json stack = mcp::json::array();
+        if (legacyVm && !m_options.disableStack)
+        {
+                for (auto const& i : legacyVm->stack())
+                        stack.push_back(toCompactHexPrefixedTrim(i));
 
-	////assert_x(ext.depth > 0);
-	//if (m_lastInst.size() == ext.depth /*- 1*/)
-	//{
-	//	// starting a new context
-	//	assert(m_lastInst.size() == ext.depth/* - 1*/);
-	//	m_lastInst.push_back(inst);
-	//	newContext = true;
-	//}
-	//else if (m_lastInst.size() == ext.depth + 2)
-	//{
-	//	m_lastInst.pop_back();
-	//	lastInst = m_lastInst.back();
-	//}
-	//else if (m_lastInst.size() == ext.depth + 1)
-	//{
-	//	// continuing in previous context
-	//	lastInst = m_lastInst.back();
-	//	m_lastInst.back() = inst;
-	//}
-	//else
-	//{
-	//	cwarn << "GAA!!! Tracing VM and more than one new/deleted stack frame between steps!";
-	//	cwarn << "Attmepting naive recovery...";
-	//	m_lastInst.resize(ext.depth + 1);
-	//}
+                r["stack"] = stack;
+        }
+        else if (interpreterVm && !m_options.disableStack)
+        {
+                for (auto const& value : interpreterVm->stackIntx())
+                        stack.push_back(toCompactHexFromIntx(value));
 
-	if (vm)
-	{
-		bytes const& memory = vm->memory();
+                r["stack"] = stack;
+        }
 
-		mcp::json memJson(mcp::json::array());
-		if (m_options.enableMemory)
-		{
-			for (unsigned i = 0; i < memory.size(); i += 32)
-			{
-				bytesConstRef memRef(memory.data() + i, 32);
-				memJson.push_back(toHex(memRef));
-			}
-			r["memory"] = memJson;
-		}
-		//r["memSize"] = static_cast<uint64_t>(memory.size());
-	}
+        if (legacyVm)
+        {
+                bytes const& memory = legacyVm->memory();
 
-	if (!m_options.disableStorage &&
-		(inst == Instruction::SLOAD || inst == Instruction::SSTORE)
-		/*(m_options.fullStorage || changesStorage(lastInst) || newContext)*/)
-	{
-		mcp::json storage(mcp::json::object());
-		for (auto const& i : ext.state().storage(ext.myAddress))
-			storage[toCompactHex(i.second.first, 32)] =
-			toCompactHex(i.second.second, 32);
-		r["storage"] = storage;
-	}
+                if (m_options.enableMemory)
+                {
+                        mcp::json memJson(mcp::json::array());
+                        for (unsigned i = 0; i < memory.size(); i += 32)
+                        {
+                                bytesConstRef memRef(memory.data() + i, 32);
+                                memJson.push_back(toHex(memRef));
+                        }
+                        r["memory"] = memJson;
+                }
+        }
+        else if (interpreterVm)
+        {
+                bytes const& memory = interpreterVm->memory();
 
-	m_outValue.push_back(r);
+                if (m_options.enableMemory)
+                {
+                        mcp::json memJson(mcp::json::array());
+                        for (unsigned i = 0; i < memory.size(); i += 32)
+                        {
+                                bytesConstRef memRef(memory.data() + i, std::min<unsigned>(32, memory.size() - i));
+                                memJson.push_back(toHex(memRef));
+                        }
+                        r["memory"] = memJson;
+                }
+        }
+
+        if (!m_options.disableStorage &&
+                (inst == Instruction::SLOAD || inst == Instruction::SSTORE))
+        {
+                mcp::json storage(mcp::json::object());
+                for (auto const& i : ext.state().storage(ext.myAddress))
+                        storage[toCompactHex(i.second.first, 32)] =
+                        toCompactHex(i.second.second, 32);
+                r["storage"] = storage;
+        }
+
+        m_outValue.push_back(r);
 }
 
 mcp::json mcp::OpCode::GetResult()
 {
-	mcp::json ret;
-	ret["gas"] = m_res->gasUsed.convert_to<uint64_t>()/*toJS(t.gas())*/;
-	ret["failed"] = m_res->Failed();
-	ret["returnValue"] = toHex(m_res->output);
-	ret["structLogs"] = m_outValue;
-	return ret;
+        mcp::json ret;
+        ret["gas"] = m_res->gasUsed.convert_to<uint64_t>()/*toJS(t.gas())*/;
+        ret["failed"] = m_res->Failed();
+        ret["returnValue"] = toHex(m_res->output);
+        ret["structLogs"] = m_outValue;
+        return ret;
 }
 
 mcp::OpCode::DebugOptions mcp::OpCode::debugOptions(mcp::json const& _json)
 {
-	mcp::OpCode::DebugOptions op;
-	if (!_json.is_object() || _json.empty())
-		return op;
-	if (_json.count("enableMemory") && !_json["enableMemory"].empty())
-		op.enableMemory = _json["enableMemory"].get<bool>();
-	if (_json.count("disableStorage") && !_json["disableStorage"].empty())
-		op.disableStorage = _json["disableStorage"].get<bool>();
-	if (_json.count("disableStack") && !_json["disableStack"].empty())
-		op.disableStack = _json["disableStack"].get<bool>();
-	//if (_json.count("full_storage") && !_json["full_storage"].empty())
-	//	op.fullStorage = _json["full_storage"].get<bool>();
-	if (_json.count("debug") && !_json["debug"].empty())
-		op.debug = _json["debug"].get<bool>();
-	if (_json.count("limit") && !_json["limit"].empty())
-		op.limit = _json["limit"].get<int>();
-	return op;
+        mcp::OpCode::DebugOptions op;
+        if (!_json.is_object() || _json.empty())
+                return op;
+        if (_json.count("enableMemory") && !_json["enableMemory"].empty())
+                op.enableMemory = _json["enableMemory"].get<bool>();
+        if (_json.count("disableStorage") && !_json["disableStorage"].empty())
+                op.disableStorage = _json["disableStorage"].get<bool>();
+        //if (_json.count("full_storage") && !_json["full_storage"].empty())
+        //      op.fullStorage = _json["full_storage"].get<bool>();
+        if (_json.count("disableStack") && !_json["disableStack"].empty())
+                op.disableStack = _json["disableStack"].get<bool>();
+        //if (_json.count("full_storage") && !_json["full_storage"].empty())
+        //      op.fullStorage = _json["full_storage"].get<bool>();
+        if (_json.count("debug") && !_json["debug"].empty())
+                op.debug = _json["debug"].get<bool>();
+        if (_json.count("limit") && !_json["limit"].empty())
+                op.limit = _json["limit"].get<int>();
+        return op;
 }

--- a/mcp/node/tracers/OpCode.hpp
+++ b/mcp/node/tracers/OpCode.hpp
@@ -17,20 +17,23 @@ namespace mcp
 			int limit = 0;// maximum length of output, but zero means unlimited
 		};
 
-		explicit OpCode(mcp::ExecutionResult& _er, mcp::json const& _param = mcp::json()) noexcept :
-			//Tracer(_er),
-			m_res{ &_er },
-			m_options(debugOptions(_param)) {}
+                explicit OpCode(mcp::ExecutionResult& _er, mcp::json const& _param = mcp::json()) noexcept :
+                        //Tracer(_er),
+                        m_res{ &_er },
+                        m_options(debugOptions(_param)) {}
 
-		void CaptureState(uint64_t PC, dev::eth::Instruction inst,
-			uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt) override;
+                void SetCurrentVM(dev::eth::VM const* _vm) override { m_currentInterpreterVm = _vm; }
 
-		mcp::json GetResult() override;
+                void CaptureState(uint64_t PC, dev::eth::Instruction inst,
+                        uint64_t gasCost, uint64_t gas, dev::eth::VMFace const* _vm, dev::eth::ExtVMFace const* voidExt) override;
 
-	private:
-		OpCode::DebugOptions debugOptions(mcp::json const& _json);
-		DebugOptions m_options;
-		mcp::json m_outValue{ mcp::json::array() };
-		ExecutionResult* m_res = nullptr;
-	};
+                mcp::json GetResult() override;
+
+        private:
+                OpCode::DebugOptions debugOptions(mcp::json const& _json);
+                DebugOptions m_options;
+                mcp::json m_outValue{ mcp::json::array() };
+                ExecutionResult* m_res = nullptr;
+                dev::eth::VM const* m_currentInterpreterVm = nullptr;
+        };
 }

--- a/mcp/node/tracers/Tracer.hpp
+++ b/mcp/node/tracers/Tracer.hpp
@@ -4,13 +4,17 @@
 #include <libevm/Logger.h>
 #include <mcp/core/common.hpp>
 
+namespace dev { namespace eth { class VM; } }
+
 namespace mcp
 {
-	class Tracer : public dev::eth::EVMLogger
-	{
-		friend class OpCode;
-	public:
-		explicit Tracer() {};
+        class Tracer : public dev::eth::EVMLogger
+        {
+                friend class OpCode;
+        public:
+                explicit Tracer() {};
+
+                virtual void SetCurrentVM(dev::eth::VM const* /*_vm*/) {}
 
 		void CaptureTxStart(uint64_t _gasLimit) override {}
 		void CaptureTxEnd(uint64_t _restGas) override {}

--- a/mcp/rpc/handler.cpp
+++ b/mcp/rpc/handler.cpp
@@ -174,8 +174,8 @@ void mcp::rpc_handler::accounts_balances(mcp::json &j_response, bool &)
 
 void mcp::rpc_handler::block(mcp::json &j_response, bool &)
 {
-	if (!mcp::isH256(params[0]))
-		BOOST_THROW_EXCEPTION(RPC_Error_JsonParseError(BadHexFormat));
+        if (!mcp::isH256(params[0]))
+                BOOST_THROW_EXCEPTION(RPC_Error_JsonParseError(BadHexFormat));
 
 	//dev::h256 block_hash = jsToHash(params[0]);
 	//mcp::db::db_transaction transaction(m_store.create_transaction());
@@ -1635,8 +1635,11 @@ void mcp::rpc_handler::approve_receipt(mcp::json &j_response, bool &)
 
 void mcp::rpc_handler::debug_traceTransaction(mcp::json &j_response, bool &)
 {
-	if (!mcp::isH256(params[0]))
-		BOOST_THROW_EXCEPTION(RPC_Error_JsonParseError(BadHexFormat));
+        if (!params.is_array() || params.empty())
+                BOOST_THROW_EXCEPTION(RPC_Error_InvalidParams("Invalid parameters"));
+
+        if (!mcp::isH256(params[0]))
+                BOOST_THROW_EXCEPTION(RPC_Error_JsonParseError(BadHexFormat));
 
 	try 
 	{
@@ -1646,10 +1649,9 @@ void mcp::rpc_handler::debug_traceTransaction(mcp::json &j_response, bool &)
 		Block block = client()->blockByHash(t.blockHash(), true);
 		
 		// Set up tracer options from params[1] (if provided)
-		mcp::json tracerOptions;
-		if (params.size() > 1 && !params[1].is_null()) {
-			tracerOptions = params[1];
-		}
+                mcp::json tracerOptions;
+                if (params.size() > 1 && params[1].is_object())
+                        tracerOptions = params[1];
 		
 		// Create execution result and tracer
 		mcp::ExecutionResult er;


### PR DESCRIPTION
## Summary
- expose the interpreter stack, memory and gas information so tracers can inspect execution
- update the opcode tracer and executive to capture interpreter state for every opcode
- implement `debug_traceTransaction` to execute the opcode tracer against archived transactions

## Testing
- not run (build tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68cdca40fea083299bd35971c3365386